### PR TITLE
feat: add Z017 missing defer after allocation lint

### DIFF
--- a/src/rules.zig
+++ b/src/rules.zig
@@ -22,6 +22,7 @@ pub const Rule = enum(u16) {
     Z020 = 20,
     Z021 = 21,
     Z022 = 22,
+    Z023 = 23,
 
     pub fn code(self: Rule) []const u8 {
         return @tagName(self);
@@ -115,6 +116,11 @@ pub const Rule = enum(u16) {
             // @This() alias in anonymous/local struct should be Self
             .Z022 => {
                 try writer.print("{s}@This(){s} alias {s}'{s}'{s} should be {s}'Self'{s}", .{ b, r, y, context, r, y, r });
+            },
+            // missing defer after allocation
+            .Z023 => {
+                // context is the variable name; defer=blue, variable=yellow
+                try writer.print("missing {s}defer{s} after allocation of {s}'{s}'{s}", .{ b, r, y, context, r });
             },
         }
     }


### PR DESCRIPTION
Detects allocator calls (alloc, create, dupe, etc.) without a corresponding defer/errdefer to free the allocated memory. Includes tests for detection and valid defer/errdefer patterns.

(Not sure if you are taking pull requests but I had a new ideas so I thought I'd offer them to you)