### PR TITLE
feat: add Z019 missing @alignCast lint

### DIFF
--- a/src/rules.zig
+++ b/src/rules.zig
@@ -22,6 +22,7 @@ pub const Rule = enum(u16) {
     Z020 = 20,
     Z021 = 21,
     Z022 = 22,
+    Z025 = 25,
 
     pub fn code(self: Rule) []const u8 {
         return @tagName(self);
@@ -115,6 +116,11 @@ pub const Rule = enum(u16) {
             // @This() alias in anonymous/local struct should be Self
             .Z022 => {
                 try writer.print("{s}@This(){s} alias {s}'{s}'{s} should be {s}'Self'{s}", .{ b, r, y, context, r, y, r });
+            },
+            // missing @alignCast
+            .Z025 => {
+                // @ptrCast=blue, @alignCast=blue
+                try writer.print("{s}@ptrCast{s} without {s}@alignCast{s} may cause alignment violations", .{ b, r, b, r });
             },
         }
     }


### PR DESCRIPTION
Detects @ptrCast calls without a wrapping @alignCast, which may cause alignment violations at runtime.

Also adds return statement and builtin call traversal to visitChildren for proper expression visiting.

Includes tests for detection and valid patterns.

(Not sure if you are taking pull requests but I had a new ideas so I thought I'd offer them to you)