### PR TITLE
Add aarch64-linux build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [aarch64-macos, x86_64-linux, x86_64-windows]
+        target: [aarch64-macos, aarch64-linux, x86_64-linux, x86_64-windows]
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - target: aarch64-macos
             artifact: ziglint-aarch64-macos
+          - target: aarch64-linux
+            artifact: ziglint-aarch64-linux
           - target: x86_64-linux
             artifact: ziglint-x86_64-linux
           - target: x86_64-windows


### PR DESCRIPTION
## Summary
- Add `aarch64-linux` cross-compilation target to CI workflow for build validation
- Add `aarch64-linux` target to release workflow to publish ARM64 Linux binaries

## Test plan
- CI will validate the new target builds successfully on PRs and pushes
- Release workflow will produce `ziglint-aarch64-linux.tar.gz` on tagged releases