### PR TITLE
feat: add --only option for rule filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Directories are scanned recursively for `.zig` files.
 ### Options
 
 - `--zig-lib-path <path>` - Override the path to the Zig standard library (auto-detected from `zig env` if not specified)
+- `--only <rule>` - Lint only the specified rule (e.g., `Z001`). Can be repeated.
 - `--ignore <rule>` - Ignore a rule (e.g., `Z001`). Can be repeated.
 - `-h, --help` - Show help message
 

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -28,6 +28,16 @@ pub fn isRuleEnabled(self: *const Config, rule: Rule) bool {
     return true;
 }
 
+/// Set whether a rule is enabled.
+pub fn setRuleEnabled(self: *Config, rule: Rule, enabled: bool) void {
+    inline for (@typeInfo(Rule).@"enum".fields) |field| {
+        if (field.value == @intFromEnum(rule)) {
+            @field(self.rules, field.name).enabled = enabled;
+            return;
+        }
+    }
+}
+
 /// Load config from .ziglint.zon file, searching from start_path up to root.
 pub fn load(allocator: std.mem.Allocator, start_path: ?[]const u8) !Config {
     const config_path = try findConfigFile(allocator, start_path) orelse return .{};
@@ -160,6 +170,18 @@ test "runtime rule check" {
     const config: Config = .{};
     const rule: Rule = .Z001;
     try std.testing.expect(config.isRuleEnabled(rule));
+}
+
+test "set rule enabled" {
+    var config: Config = .{};
+
+    try std.testing.expect(!config.isRuleEnabled(.Z033));
+    config.setRuleEnabled(.Z033, true);
+    try std.testing.expect(config.isRuleEnabled(.Z033));
+
+    try std.testing.expect(config.isRuleEnabled(.Z001));
+    config.setRuleEnabled(.Z001, false);
+    try std.testing.expect(!config.isRuleEnabled(.Z001));
 }
 
 test "parse paths config" {


### PR DESCRIPTION
Currently it only supports subtractive filtering through --ignore. Single-rule runs require you to ignore every other rule or pipe it to grep.

Add repeatable --only <rule>. After loading .ziglint.zon, disable all rules, enable only selected rules, then apply --ignore so explicit ignores still take precedence.

Feel free to close if this goes in a different direction then where you want to go.