### PR TITLE
build: specify minimum zig version

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,7 @@
     .name = .ziglint,
     .version = "0.5.2",
     .fingerprint = 0x4b7deecc2ff046b7,
+    .minimum_zig_version = "0.15.2",
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
I like Jonathan's [anyzig](https://github.com/marler8997/anyzig) project and it requires you to set the minimum zig version. 

Minor quality of life thing so i don't have to run `zig <version> build` and can instead write `zig build`