### PR TITLE
fix(TypeResolver): bound nodeIsTypeRef alias recursion (stack-overflow DoS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
       - run: zig build test
 
   build:
@@ -25,5 +25,5 @@ jobs:
       - uses: actions/checkout@v6
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
       - run: zig build -Dtarget=${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
           - target: x86_64-windows
             artifact: ziglint-x86_64-windows
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build
         run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}
@@ -54,7 +54,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
+.zig-global-cache/
 zig-out/
 *.o

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,10 @@ b.addExecutable(.{
 ## Zig Code Style
 
 **Naming:**
-- `camelCase` for functions and methods
-- `snake_case` for variables and parameters
+- `camelCase` for functions and methods (`PascalCase` when returning a type)
+- `snake_case` for variables, parameters, and value constants — Zig stdlib
+  convention (e.g. `std.fs.max_path_bytes`), enforced by Z006
 - `PascalCase` for types, structs, and enums
-- `SCREAMING_SNAKE_CASE` for constants
 
 **Struct initialization:** Prefer explicit type annotation with anonymous literals:
 ```zig

--- a/build.zig
+++ b/build.zig
@@ -47,27 +47,17 @@ pub fn build(b: *std.Build) void {
     const fmt_check = b.addFmt(.{ .paths = &.{ "src", "build.zig", "build.zig.zon" } });
     test_step.dependOn(&fmt_check.step);
 
-    // Self-lint: the public `addLint` API enforces exit code 0 (so downstream
-    // users can fail their CI on findings). For our own `zig build test`
-    // aggregate we want to ensure ziglint doesn't *crash* on its own source,
-    // but we tolerate the residual lint findings (mostly stylistic) that
-    // remain after the Zig 0.16 migration.
     const lint_step = addLint(b, exe, &.{ b.path("src"), b.path("build.zig") });
     const lint_alias = b.step("lint", "Run ziglint on this repository");
     lint_alias.dependOn(lint_step);
 
-    // A separate "self-lint smoke" run gated into `zig build test`.
-    // Ziglint currently reports residual style findings (Z011/Z012/Z013/Z023)
-    // against its own Zig 0.16-migrated source. Until those are addressed we
-    // expect exit code 1 (findings reported), which still proves ziglint did
-    // not crash (segfault/ABRT). When the codebase becomes lint-clean this
-    // will start failing -- swap to `expectExitCode(0)` at that point.
+    // Keep self-lint in the test aggregate so regressions break the normal gate.
     const lint_smoke = b.addRunArtifact(exe);
     lint_smoke.addDirectoryArg(b.path("src"));
     lint_smoke.addFileArg(b.path("build.zig"));
     addPathInputs(b, lint_smoke, b.path("src"));
     addPathInputs(b, lint_smoke, b.path("build.zig"));
-    lint_smoke.expectExitCode(1);
+    lint_smoke.expectExitCode(0);
     test_step.dependOn(&lint_smoke.step);
 }
 
@@ -133,10 +123,10 @@ fn getVersion(b: *std.Build) []const u8 {
     const trimmed = std.mem.trim(u8, git_describe, " \n\r");
     const without_v = if (trimmed.len > 0 and trimmed[0] == 'v') trimmed[1..] else trimmed;
 
-    if (std.mem.indexOfScalar(u8, without_v, '-')) |dash_idx| {
+    if (std.mem.findScalar(u8, without_v, '-')) |dash_idx| {
         const tag_part = without_v[0..dash_idx];
         const rest = without_v[dash_idx + 1 ..];
-        if (std.mem.indexOfScalar(u8, rest, '-')) |second_dash| {
+        if (std.mem.findScalar(u8, rest, '-')) |second_dash| {
             const count = rest[0..second_dash];
             const hash = rest[second_dash + 1 ..];
             const hash_without_g = if (hash.len > 0 and hash[0] == 'g') hash[1..] else hash;

--- a/build.zig
+++ b/build.zig
@@ -47,8 +47,28 @@ pub fn build(b: *std.Build) void {
     const fmt_check = b.addFmt(.{ .paths = &.{ "src", "build.zig", "build.zig.zon" } });
     test_step.dependOn(&fmt_check.step);
 
+    // Self-lint: the public `addLint` API enforces exit code 0 (so downstream
+    // users can fail their CI on findings). For our own `zig build test`
+    // aggregate we want to ensure ziglint doesn't *crash* on its own source,
+    // but we tolerate the residual lint findings (mostly stylistic) that
+    // remain after the Zig 0.16 migration.
     const lint_step = addLint(b, exe, &.{ b.path("src"), b.path("build.zig") });
-    test_step.dependOn(lint_step);
+    const lint_alias = b.step("lint", "Run ziglint on this repository");
+    lint_alias.dependOn(lint_step);
+
+    // A separate "self-lint smoke" run gated into `zig build test`.
+    // Ziglint currently reports residual style findings (Z011/Z012/Z013/Z023)
+    // against its own Zig 0.16-migrated source. Until those are addressed we
+    // expect exit code 1 (findings reported), which still proves ziglint did
+    // not crash (segfault/ABRT). When the codebase becomes lint-clean this
+    // will start failing -- swap to `expectExitCode(0)` at that point.
+    const lint_smoke = b.addRunArtifact(exe);
+    lint_smoke.addDirectoryArg(b.path("src"));
+    lint_smoke.addFileArg(b.path("build.zig"));
+    addPathInputs(b, lint_smoke, b.path("src"));
+    addPathInputs(b, lint_smoke, b.path("build.zig"));
+    lint_smoke.expectExitCode(1);
+    test_step.dependOn(&lint_smoke.step);
 }
 
 /// Add a ziglint step to your build. Use as a dependency to run linting.
@@ -87,16 +107,15 @@ fn addPathInputs(b: *std.Build, run: *std.Build.Step.Run, lazy_path: std.Build.L
         else => return,
     };
 
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const full_path = src.owner.build_root.handle.realpathZ(@ptrCast(src.sub_path), &buf) catch return;
+    const full_path = src.owner.build_root.join(b.allocator, &.{src.sub_path}) catch return;
 
-    const stat = std.fs.cwd().statFile(full_path) catch return;
+    const stat = std.Io.Dir.cwd().statFile(b.graph.io, full_path, .{}) catch return;
     if (stat.kind == .directory) {
-        var dir = std.fs.cwd().openDir(full_path, .{ .iterate = true }) catch return;
-        defer dir.close();
+        var dir = std.Io.Dir.cwd().openDir(b.graph.io, full_path, .{ .iterate = true }) catch return;
+        defer dir.close(b.graph.io);
         var walker = dir.walk(b.allocator) catch return;
         defer walker.deinit();
-        while (walker.next() catch null) |entry| {
+        while (walker.next(b.graph.io) catch null) |entry| {
             if (entry.kind == .file and std.mem.endsWith(u8, entry.basename, ".zig")) {
                 run.addFileInput(lazy_path.path(run.step.owner, entry.path));
             }
@@ -108,7 +127,7 @@ fn addPathInputs(b: *std.Build, run: *std.Build.Step.Run, lazy_path: std.Build.L
 
 fn getVersion(b: *std.Build) []const u8 {
     var code: u8 = undefined;
-    const git_describe = b.runAllowFail(&.{ "git", "describe", "--match", "v*.*.*", "--tags" }, &code, .Ignore) catch {
+    const git_describe = b.runAllowFail(&.{ "git", "describe", "--match", "v*.*.*", "--tags" }, &code, .ignore) catch {
         return "unknown";
     };
     const trimmed = std.mem.trim(u8, git_describe, " \n\r");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .ziglint,
     .version = "0.5.2",
     .fingerprint = 0x4b7deecc2ff046b7,
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/docs/rules/Z002.md
+++ b/docs/rules/Z002.md
@@ -13,7 +13,7 @@ Detects variables that are assigned a value but never used. If you don't need th
 ### Bad
 
 ```zig
-// expect: Z002
+// expect: Z002, Z031
 const _unused = getValue();
 ```
 

--- a/docs/rules/Z007.md
+++ b/docs/rules/Z007.md
@@ -13,7 +13,7 @@ Detects when the same module is imported multiple times in the same file.
 ### Bad
 
 ```zig
-// expect: Z007
+// expect: Z007, Z013
 const std = @import("std");
 const std2 = @import("std");
 ```

--- a/docs/rules/Z011.md
+++ b/docs/rules/Z011.md
@@ -21,7 +21,7 @@ const MyType = struct {
     }
 };
 const instance: MyType = .{};
-// expect: Z011
+// expect: Z011, Z020
 pub fn main() void {
     instance.oldMethod();
 }

--- a/docs/rules/Z021.md
+++ b/docs/rules/Z021.md
@@ -15,7 +15,7 @@ In file-as-struct patterns (files with top-level fields), the `@This()` alias sh
 In a file named `Config.zig`:
 
 ```zig
-// expect: Z021
+// expect: Z021, Z009
 const Wrong = @This();
 
 value: u32,

--- a/docs/rules/Z031.md
+++ b/docs/rules/Z031.md
@@ -18,7 +18,7 @@ fn _privateHelper() void {}
 ```
 
 ```zig
-// expect: Z031
+// expect: Z031, Z002
 const _internalValue: u32 = undefined;
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,38 +18,19 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "mattware": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ],
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1769379533,
-        "narHash": "sha256-6td2HWGfSsDBGUuNiSBJWi9g+rlXV/ofFj/3I7Cjf3Y=",
+        "lastModified": 1779338067,
+        "narHash": "sha256-GNLYE11onSW2ejYny0REOARb7YnfEvtCvdAYNBSUy+U=",
         "owner": "mattrobenolt",
         "repo": "nixpkgs",
-        "rev": "7929699dfb372f8bfbd93b24460e35089b49eedb",
+        "rev": "43044093d1939ef08f8f4eba36a4f67ddffdda43",
         "type": "github"
       },
       "original": {
@@ -60,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769461804,
-        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -96,21 +77,6 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -119,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768158989,
-        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,9 +28,8 @@
       {
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
-            zig_0_15
-            zls_0_15
-            zlint
+            zig_0_16
+            zls_0_16
             zigdoc
           ];
 

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -39,20 +39,20 @@ pub fn setRuleEnabled(self: *Config, rule: Rule, enabled: bool) void {
 }
 
 /// Load config from .ziglint.zon file, searching from start_path up to root.
-pub fn load(io: std.Io, allocator: std.mem.Allocator, start_path: ?[]const u8) !Config {
-    const config_path = try findConfigFile(io, allocator, start_path) orelse return .{};
+pub fn load(allocator: std.mem.Allocator, io: std.Io, start_path: ?[]const u8) !Config {
+    const config_path = try findConfigFile(allocator, io, start_path) orelse return .{};
     defer allocator.free(config_path);
 
-    return parseConfigFile(io, allocator, config_path) catch |err| {
+    return parseConfigFile(allocator, io, config_path) catch |err| {
         std.debug.print("warning: failed to parse {s}: {}\n", .{ config_path, err });
         return .{};
     };
 }
 
 /// Find .ziglint.zon by walking up from start_path.
-fn findConfigFile(io: std.Io, allocator: std.mem.Allocator, start_path: ?[]const u8) !?[]const u8 {
+fn findConfigFile(allocator: std.mem.Allocator, io: std.Io, start_path: ?[]const u8) !?[]const u8 {
     const path = start_path orelse {
-        return findConfigInDir(io, allocator, ".");
+        return findConfigInDir(allocator, io, ".");
     };
 
     const abs_path_z = std.Io.Dir.cwd().realPathFileAlloc(io, path, allocator) catch null;
@@ -61,7 +61,7 @@ fn findConfigFile(io: std.Io, allocator: std.mem.Allocator, start_path: ?[]const
 
     var current = abs_path;
     while (true) {
-        if (try findConfigInDir(io, allocator, current)) |config_path| {
+        if (try findConfigInDir(allocator, io, current)) |config_path| {
             return config_path;
         }
 
@@ -73,7 +73,7 @@ fn findConfigFile(io: std.Io, allocator: std.mem.Allocator, start_path: ?[]const
     return null;
 }
 
-fn findConfigInDir(io: std.Io, allocator: std.mem.Allocator, dir_path: []const u8) !?[]const u8 {
+fn findConfigInDir(allocator: std.mem.Allocator, io: std.Io, dir_path: []const u8) !?[]const u8 {
     const config_path = try std.fs.path.join(allocator, &.{ dir_path, ".ziglint.zon" });
     errdefer allocator.free(config_path);
 
@@ -91,7 +91,7 @@ const ZonConfig = struct {
     rules: ?Rule.Config = null,
 };
 
-fn parseConfigFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !Config {
+fn parseConfigFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8) !Config {
     const source = try std.Io.Dir.cwd().readFileAllocOptions(
         io,
         path,

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -39,28 +39,29 @@ pub fn setRuleEnabled(self: *Config, rule: Rule, enabled: bool) void {
 }
 
 /// Load config from .ziglint.zon file, searching from start_path up to root.
-pub fn load(allocator: std.mem.Allocator, start_path: ?[]const u8) !Config {
-    const config_path = try findConfigFile(allocator, start_path) orelse return .{};
+pub fn load(io: std.Io, allocator: std.mem.Allocator, start_path: ?[]const u8) !Config {
+    const config_path = try findConfigFile(io, allocator, start_path) orelse return .{};
     defer allocator.free(config_path);
 
-    return parseConfigFile(allocator, config_path) catch |err| {
+    return parseConfigFile(io, allocator, config_path) catch |err| {
         std.debug.print("warning: failed to parse {s}: {}\n", .{ config_path, err });
         return .{};
     };
 }
 
 /// Find .ziglint.zon by walking up from start_path.
-fn findConfigFile(allocator: std.mem.Allocator, start_path: ?[]const u8) !?[]const u8 {
+fn findConfigFile(io: std.Io, allocator: std.mem.Allocator, start_path: ?[]const u8) !?[]const u8 {
     const path = start_path orelse {
-        return findConfigInDir(allocator, ".");
+        return findConfigInDir(io, allocator, ".");
     };
 
-    const abs_path = std.fs.cwd().realpathAlloc(allocator, path) catch path;
-    defer if (abs_path.ptr != path.ptr) allocator.free(abs_path);
+    const abs_path_z = std.Io.Dir.cwd().realPathFileAlloc(io, path, allocator) catch null;
+    defer if (abs_path_z) |p| allocator.free(p);
+    const abs_path: []const u8 = if (abs_path_z) |p| p else path;
 
     var current = abs_path;
     while (true) {
-        if (try findConfigInDir(allocator, current)) |config_path| {
+        if (try findConfigInDir(io, allocator, current)) |config_path| {
             return config_path;
         }
 
@@ -72,11 +73,11 @@ fn findConfigFile(allocator: std.mem.Allocator, start_path: ?[]const u8) !?[]con
     return null;
 }
 
-fn findConfigInDir(allocator: std.mem.Allocator, dir_path: []const u8) !?[]const u8 {
+fn findConfigInDir(io: std.Io, allocator: std.mem.Allocator, dir_path: []const u8) !?[]const u8 {
     const config_path = try std.fs.path.join(allocator, &.{ dir_path, ".ziglint.zon" });
     errdefer allocator.free(config_path);
 
-    std.fs.cwd().access(config_path, .{}) catch {
+    std.Io.Dir.cwd().access(io, config_path, .{}) catch {
         allocator.free(config_path);
         return null;
     };
@@ -90,12 +91,12 @@ const ZonConfig = struct {
     rules: ?Rule.Config = null,
 };
 
-fn parseConfigFile(allocator: std.mem.Allocator, path: []const u8) !Config {
-    const source = try std.fs.cwd().readFileAllocOptions(
-        allocator,
+fn parseConfigFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !Config {
+    const source = try std.Io.Dir.cwd().readFileAllocOptions(
+        io,
         path,
-        1024 * 1024,
-        null,
+        allocator,
+        .limited(1024 * 1024),
         .@"1",
         0,
     );
@@ -105,7 +106,7 @@ fn parseConfigFile(allocator: std.mem.Allocator, path: []const u8) !Config {
 }
 
 fn parseConfigSource(allocator: std.mem.Allocator, source: [:0]const u8) !Config {
-    const zon_config = std.zon.parse.fromSlice(ZonConfig, allocator, source, null, .{}) catch {
+    const zon_config = std.zon.parse.fromSliceAlloc(ZonConfig, allocator, source, null, .{}) catch {
         return error.ParseError;
     };
     defer std.zon.parse.free(allocator, zon_config);

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -3,7 +3,9 @@
 
 const std = @import("std");
 
-const Rule = @import("rules.zig").Rule;
+/// Public re-export: `isRuleEnabled`/`setRuleEnabled` take a `Rule`, so the
+/// type must be reachable from this namespace by callers (ziglint Z012).
+pub const Rule = @import("rules.zig").Rule;
 
 const Config = @This();
 
@@ -26,6 +28,15 @@ pub fn isRuleEnabled(self: *const Config, rule: Rule) bool {
         }
     }
     return true;
+}
+
+/// Frees the `paths` entries allocated by `parseConfigSource` and leaves
+/// the config invalidated. Safe to call on a default-initialized `Config`
+/// (the default `paths` slice is empty and never freed).
+pub fn deinit(self: *Config, allocator: std.mem.Allocator) void {
+    for (self.paths) |p| allocator.free(p);
+    if (self.paths.len > 0) allocator.free(self.paths);
+    self.* = undefined;
 }
 
 /// Set whether a rule is enabled.
@@ -194,11 +205,8 @@ test "parse paths config" {
         \\    },
         \\}
     ;
-    const config = try parseConfigSource(std.testing.allocator, source);
-    defer {
-        for (config.paths) |item| std.testing.allocator.free(item);
-        std.testing.allocator.free(config.paths);
-    }
+    var config = try parseConfigSource(std.testing.allocator, source);
+    defer config.deinit(std.testing.allocator);
     try std.testing.expectEqual(2, config.paths.len);
     try std.testing.expectEqualStrings("src", config.paths[0]);
     try std.testing.expectEqualStrings("lib", config.paths[1]);

--- a/src/Linter.zig
+++ b/src/Linter.zig
@@ -28,10 +28,10 @@ const Linter = @This();
 /// in Linter is diagnostic-only (perf debug), so we degrade reads to 0 here and
 /// leave the wider Io plumbing for a follow-up refactor.
 const Timer = struct {
-    pub fn start() error{}!Timer {
+    fn start() error{}!Timer {
         return .{};
     }
-    pub fn read(_: *Timer) u64 {
+    fn read(_: *Timer) u64 {
         return 0;
     }
 };
@@ -983,7 +983,7 @@ fn isTypeExpression(self: *Linter, node: Ast.Node.Index) bool {
         // Builtin type constructors
         .builtin_call_two, .builtin_call_two_comma, .builtin_call, .builtin_call_comma => blk: {
             const token = self.tree.tokenSlice(self.tree.nodeMainToken(node));
-            break :blk std.mem.eql(u8, token, "@Type");
+            break :blk isBuiltinTypeConstructor(token);
         },
         // Identifier referencing another type (type alias)
         .identifier => blk: {
@@ -1074,6 +1074,38 @@ fn isBuiltinType(name: []const u8) bool {
         "f16",          "f32",            "f64",  "f80",      "f128",    "bool",
         "void",         "noreturn",       "type", "anyerror", "anytype", "anyframe",
         "comptime_int", "comptime_float",
+    };
+    for (builtins) |b| {
+        if (std.mem.eql(u8, name, b)) return true;
+    }
+    return false;
+}
+
+fn isBuiltinTypeConstructor(name: []const u8) bool {
+    const builtins = [_][]const u8{
+        "@This",
+        "@import",
+        "@Type",
+        "@TypeOf",
+        "@Int",
+        "@Float",
+        "@Pointer",
+        "@Array",
+        "@Vector",
+        "@Optional",
+        "@ErrorUnion",
+        "@ErrorSet",
+        "@Enum",
+        // @EnumLiteral() type and @Tuple(comptime field_types: []const type) type
+        // are documented Zig 0.16 type-constructor builtins (langref §@EnumLiteral,
+        // §@Tuple). They return `type`, so they belong in this list.
+        "@EnumLiteral",
+        "@Union",
+        "@Struct",
+        "@Opaque",
+        "@Fn",
+        "@Frame",
+        "@Tuple",
     };
     for (builtins) |b| {
         if (std.mem.eql(u8, name, b)) return true;
@@ -2404,7 +2436,7 @@ fn checkRedundantType(self: *Linter, node: Ast.Node.Index, check_field_access: b
         const full_expr = self.getNodeSource(node);
         const type_name = self.tree.tokenSlice(type_token);
         // Find where the type name ends and extract the { ... } part
-        const brace_start = std.mem.indexOf(u8, full_expr, "{") orelse return;
+        const brace_start = std.mem.find(u8, full_expr, "{") orelse return;
         const fields_part = truncateExpr(full_expr[brace_start..]);
         const full_truncated = truncateExpr(full_expr);
         const msg = std.fmt.allocPrint(self.allocator, ".{s}\x00{s}", .{ fields_part, full_truncated }) catch return;
@@ -2457,7 +2489,7 @@ fn truncateExpr(expr: []const u8) []const u8 {
     const max_len = 32;
     if (expr.len <= max_len) return expr;
     // Find a good break point (after opening brace if present)
-    if (std.mem.indexOf(u8, expr[0..@min(max_len, expr.len)], "{")) |brace| {
+    if (std.mem.find(u8, expr[0..@min(max_len, expr.len)], "{")) |brace| {
         return expr[0 .. brace + 1];
     }
     return expr[0..max_len];
@@ -2691,10 +2723,7 @@ fn isTypeAlias(self: *Linter, var_decl: Ast.full.VarDecl) bool {
         },
         .builtin_call_two, .builtin_call_two_comma, .builtin_call, .builtin_call_comma => blk: {
             const token = self.tree.tokenSlice(self.tree.nodeMainToken(init_node));
-            break :blk std.mem.eql(u8, token, "@This") or
-                std.mem.eql(u8, token, "@import") or
-                std.mem.eql(u8, token, "@Type") or
-                std.mem.eql(u8, token, "@TypeOf");
+            break :blk isBuiltinTypeConstructor(token);
         },
         .call_one, .call_one_comma => blk: {
             // Check if calling a PascalCase function (type constructor)
@@ -2819,9 +2848,9 @@ fn isIgnored(self: *Linter, line: usize, rule: rules.Rule) bool {
 }
 
 fn lineHasIgnore(_: *Linter, line_text: []const u8, rule: rules.Rule) bool {
-    if (std.mem.indexOf(u8, line_text, "// ziglint-ignore:")) |idx| {
+    if (std.mem.find(u8, line_text, "// ziglint-ignore:")) |idx| {
         const ignore_part = line_text[idx + 18 ..];
-        if (std.mem.indexOf(u8, ignore_part, rule.code()) != null) return true;
+        if (std.mem.find(u8, ignore_part, rule.code()) != null) return true;
     }
     return false;
 }
@@ -3099,8 +3128,8 @@ test "Z006: allow type alias with @import()" {
     }
 }
 
-test "Z006: allow type alias with @Type()" {
-    var linter: Linter = .init(std.testing.allocator, "const MyType = @Type(.{ .int = .{ .signedness = .unsigned, .bits = 8 } });", "test.zig", null);
+test "Z006: allow type alias with @Int()" {
+    var linter: Linter = .init(std.testing.allocator, "const MyType = @Int(.unsigned, 8);", "test.zig", null);
     defer linter.deinit();
     linter.lint();
     try std.testing.expectEqual(0, linter.diagnosticCount(.Z006));
@@ -3181,12 +3210,10 @@ test "Z006: allow type alias with primitive type" {
 test "Z006: allow PascalCase labeled block type alias" {
     var linter: Linter = .init(std.testing.allocator,
         \\const Config = blk: {
-        \\    break :blk @Type(.{ .@"struct" = .{
-        \\        .layout = .auto,
-        \\        .fields = &.{},
-        \\        .decls = &.{},
-        \\        .is_tuple = false,
-        \\    } });
+        \\    const field_names = [_][]const u8{};
+        \\    const field_types = [_]type{};
+        \\    const field_attrs = [_]std.builtin.Type.StructField.Attributes{};
+        \\    break :blk @Struct(.auto, null, &field_names, &field_types, &field_attrs);
         \\};
     , "test.zig", null);
     defer linter.deinit();
@@ -3526,7 +3553,7 @@ test "Z011: detect deprecated method call" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3570,7 +3597,7 @@ test "Z011: no warning for non-deprecated method" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3624,7 +3651,7 @@ test "Z011: detect deprecated direct function call" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3663,7 +3690,7 @@ test "Z011: detect deprecated function alias" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3703,7 +3730,7 @@ test "Z011: detect deprecated type function" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3744,7 +3771,7 @@ test "Z011: detect deprecated type function alias" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3783,9 +3810,9 @@ test "Z011: detect deprecated stdlib function (ArrayListUnmanaged)" {
         }
 
         const needle = ".lib_dir = \"";
-        const start_idx = std.mem.indexOf(u8, result.stdout, needle) orelse break :blk null;
+        const start_idx = std.mem.find(u8, result.stdout, needle) orelse break :blk null;
         const value_start = start_idx + needle.len;
-        const end_idx = std.mem.indexOfPos(u8, result.stdout, value_start, "\"") orelse break :blk null;
+        const end_idx = std.mem.findPos(u8, result.stdout, value_start, "\"") orelse break :blk null;
         break :blk std.testing.allocator.dupe(u8, result.stdout[value_start..end_idx]) catch null;
     };
 
@@ -3807,7 +3834,7 @@ test "Z011: detect deprecated stdlib function (ArrayListUnmanaged)" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, zig_lib_path);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, zig_lib_path);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3846,9 +3873,9 @@ test "Z011: deprecated stdlib corpus - real Zig 0.15.2 deprecations" {
         }
 
         const needle = ".lib_dir = \"";
-        const start_idx = std.mem.indexOf(u8, result.stdout, needle) orelse break :blk null;
+        const start_idx = std.mem.find(u8, result.stdout, needle) orelse break :blk null;
         const value_start = start_idx + needle.len;
-        const end_idx = std.mem.indexOfPos(u8, result.stdout, value_start, "\"") orelse break :blk null;
+        const end_idx = std.mem.findPos(u8, result.stdout, value_start, "\"") orelse break :blk null;
         break :blk std.testing.allocator.dupe(u8, result.stdout[value_start..end_idx]) catch null;
     };
 
@@ -3999,7 +4026,7 @@ test "Z011: deprecated stdlib corpus - real Zig 0.15.2 deprecations" {
         const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
         defer std.testing.allocator.free(path);
 
-        var graph = try ModuleGraph.init(io, std.testing.allocator, path, zig_lib_path);
+        var graph = try ModuleGraph.init(std.testing.allocator, io, path, zig_lib_path);
         defer graph.deinit();
 
         var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -4683,7 +4710,7 @@ test "Z023: argument order - aliased Allocator" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -4717,7 +4744,7 @@ test "Z023: argument order - aliased Io" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -4785,7 +4812,7 @@ test "Z023: receiver param with struct name is ok (semantic)" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -4817,7 +4844,7 @@ test "Z023: file-as-struct receiver is ok (semantic)" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "Terminal.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5188,7 +5215,7 @@ test "Z027: flag instance accessing const" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5229,7 +5256,7 @@ test "Z027: flag instance accessing static fn" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5272,7 +5299,7 @@ test "Z027: allow instance method call" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5309,7 +5336,7 @@ test "Z027: allow field access" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5346,7 +5373,7 @@ test "Z027: allow type-level access" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5406,7 +5433,7 @@ test "Z027: allow method with Self receiver" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5446,7 +5473,7 @@ test "Z027: allow method with named type receiver" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5538,7 +5565,7 @@ test "Z029: detect redundant @as in method call arg" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);

--- a/src/Linter.zig
+++ b/src/Linter.zig
@@ -22,6 +22,26 @@ pub const DeprecationKey = struct {
 
 const Linter = @This();
 
+/// Stub Timer for Zig 0.16 compatibility.
+/// Timer was removed in 0.16; the proper replacement requires threading
+/// std.Io through Linter, which would touch 200+ test call sites. Verbose timing
+/// in Linter is diagnostic-only (perf debug), so we degrade reads to 0 here and
+/// leave the wider Io plumbing for a follow-up refactor.
+const Timer = struct {
+    pub fn start() error{}!Timer {
+        return .{};
+    }
+    pub fn read(_: *Timer) u64 {
+        return 0;
+    }
+};
+
+/// Test-only Io provider. Tests are synchronous and don't need cancelation,
+/// so we use the global single-threaded Io instance.
+fn testIo() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
 allocator: std.mem.Allocator,
 source: [:0]const u8,
 path: []const u8,
@@ -44,7 +64,7 @@ verbose: bool = false,
 use_color: bool = false,
 /// Track time spent checking each rule type (nanoseconds)
 rule_timings: std.AutoHashMapUnmanaged(rules.Rule, u64) = .empty,
-rule_timer: ?std.time.Timer = null,
+rule_timer: ?Timer = null,
 
 const default_config: Config = .{};
 
@@ -151,9 +171,9 @@ pub fn deinit(self: *Linter) void {
 }
 
 pub fn lint(self: *Linter) void {
-    var timer = if (self.verbose) std.time.Timer.start() catch null else null;
+    var timer = if (self.verbose) Timer.start() catch null else null;
     if (self.verbose) {
-        self.rule_timer = std.time.Timer.start() catch null;
+        self.rule_timer = Timer.start() catch null;
     }
 
     const dim = if (self.use_color) "\x1b[2m" else "";
@@ -3501,11 +3521,12 @@ test "Z011: detect deprecated method call" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3544,11 +3565,12 @@ test "Z011: no warning for non-deprecated method" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3597,11 +3619,12 @@ test "Z011: detect deprecated direct function call" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3635,11 +3658,12 @@ test "Z011: detect deprecated function alias" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3674,11 +3698,12 @@ test "Z011: detect deprecated type function" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3714,11 +3739,12 @@ test "Z011: detect deprecated type function alias" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3742,28 +3768,25 @@ test "Z011: detect deprecated type function alias" {
 test "Z011: detect deprecated stdlib function (ArrayListUnmanaged)" {
 
     // Detect zig lib path by running zig env
+    const io = testIo();
     const zig_lib_path = blk: {
-        var child: std.process.Child = .init(&.{ "zig", "env" }, std.testing.allocator);
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Ignore;
-        child.spawn() catch break :blk null;
+        const result = std.process.run(std.testing.allocator, io, .{
+            .argv = &.{ "zig", "env" },
+            .stderr_limit = .nothing,
+        }) catch break :blk null;
+        defer std.testing.allocator.free(result.stdout);
+        defer std.testing.allocator.free(result.stderr);
 
-        var buf: [64 * 1024]u8 = undefined;
-        const stdout = child.stdout orelse break :blk null;
-        const len = stdout.readAll(&buf) catch break :blk null;
-        const output = buf[0..len];
-
-        const term = child.wait() catch break :blk null;
-        switch (term) {
-            .Exited => |code| if (code != 0) break :blk null,
+        switch (result.term) {
+            .exited => |code| if (code != 0) break :blk null,
             else => break :blk null,
         }
 
         const needle = ".lib_dir = \"";
-        const start_idx = std.mem.indexOf(u8, output, needle) orelse break :blk null;
+        const start_idx = std.mem.indexOf(u8, result.stdout, needle) orelse break :blk null;
         const value_start = start_idx + needle.len;
-        const end_idx = std.mem.indexOfPos(u8, output, value_start, "\"") orelse break :blk null;
-        break :blk std.testing.allocator.dupe(u8, output[value_start..end_idx]) catch null;
+        const end_idx = std.mem.indexOfPos(u8, result.stdout, value_start, "\"") orelse break :blk null;
+        break :blk std.testing.allocator.dupe(u8, result.stdout[value_start..end_idx]) catch null;
     };
 
     // Skip test if zig isn't available
@@ -3780,11 +3803,11 @@ test "Z011: detect deprecated stdlib function (ArrayListUnmanaged)" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, zig_lib_path);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, zig_lib_path);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -3808,28 +3831,25 @@ test "Z011: detect deprecated stdlib function (ArrayListUnmanaged)" {
 test "Z011: deprecated stdlib corpus - real Zig 0.15.2 deprecations" {
 
     // Detect zig lib path by running zig env
+    const io = testIo();
     const zig_lib_path = blk: {
-        var child: std.process.Child = .init(&.{ "zig", "env" }, std.testing.allocator);
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Ignore;
-        child.spawn() catch break :blk null;
+        const result = std.process.run(std.testing.allocator, io, .{
+            .argv = &.{ "zig", "env" },
+            .stderr_limit = .nothing,
+        }) catch break :blk null;
+        defer std.testing.allocator.free(result.stdout);
+        defer std.testing.allocator.free(result.stderr);
 
-        var buf: [64 * 1024]u8 = undefined;
-        const stdout = child.stdout orelse break :blk null;
-        const len = stdout.readAll(&buf) catch break :blk null;
-        const output = buf[0..len];
-
-        const term = child.wait() catch break :blk null;
-        switch (term) {
-            .Exited => |code| if (code != 0) break :blk null,
+        switch (result.term) {
+            .exited => |code| if (code != 0) break :blk null,
             else => break :blk null,
         }
 
         const needle = ".lib_dir = \"";
-        const start_idx = std.mem.indexOf(u8, output, needle) orelse break :blk null;
+        const start_idx = std.mem.indexOf(u8, result.stdout, needle) orelse break :blk null;
         const value_start = start_idx + needle.len;
-        const end_idx = std.mem.indexOfPos(u8, output, value_start, "\"") orelse break :blk null;
-        break :blk std.testing.allocator.dupe(u8, output[value_start..end_idx]) catch null;
+        const end_idx = std.mem.indexOfPos(u8, result.stdout, value_start, "\"") orelse break :blk null;
+        break :blk std.testing.allocator.dupe(u8, result.stdout[value_start..end_idx]) catch null;
     };
 
     // Skip test if zig isn't available
@@ -3975,11 +3995,11 @@ test "Z011: deprecated stdlib corpus - real Zig 0.15.2 deprecations" {
             continue;
         }
 
-        try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = tc.source });
-        const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+        try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = tc.source });
+        const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
         defer std.testing.allocator.free(path);
 
-        var graph = try ModuleGraph.init(std.testing.allocator, path, zig_lib_path);
+        var graph = try ModuleGraph.init(io, std.testing.allocator, path, zig_lib_path);
         defer graph.deinit();
 
         var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -4658,11 +4678,12 @@ test "Z023: argument order - aliased Allocator" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -4691,11 +4712,12 @@ test "Z023: argument order - aliased Io" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -4758,11 +4780,12 @@ test "Z023: receiver param with struct name is ok (semantic)" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -4789,11 +4812,12 @@ test "Z023: file-as-struct receiver is ok (semantic)" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "Terminal.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "Terminal.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "Terminal.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "Terminal.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5159,11 +5183,12 @@ test "Z027: flag instance accessing const" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5199,11 +5224,12 @@ test "Z027: flag instance accessing static fn" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5241,11 +5267,12 @@ test "Z027: allow instance method call" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5277,11 +5304,12 @@ test "Z027: allow field access" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5313,11 +5341,12 @@ test "Z027: allow type-level access" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5372,11 +5401,12 @@ test "Z027: allow method with Self receiver" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5411,11 +5441,12 @@ test "Z027: allow method with named type receiver" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -5502,11 +5533,12 @@ test "Z029: detect redundant @as in method call arg" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);

--- a/src/ModuleGraph.zig
+++ b/src/ModuleGraph.zig
@@ -11,22 +11,29 @@ const AstGen = std.zig.AstGen;
 const ModuleGraph = @This();
 
 allocator: std.mem.Allocator,
+io: std.Io,
 zig_lib_path: ?[]const u8,
 root_dir: []const u8,
 modules: std.StringHashMapUnmanaged(Module),
 
 pub const Module = struct {
-    path: []const u8,
+    /// Sentinel-terminated to match the buffer returned by `realPathFileAlloc`,
+    /// which allocates `len + 1` bytes. Storing it as `[:0]const u8` keeps the
+    /// free path size-accurate (no implicit slice-shortening) and avoids the
+    /// previous "alloc then dupe" double allocation. The sentinel is a useful
+    /// extra (paths can be passed to libc-style APIs without re-duping).
+    path: [:0]const u8,
     source: [:0]const u8,
     tree: Ast,
     zir: ?Zir = null,
 };
 
-pub fn init(allocator: std.mem.Allocator, root_source: []const u8, zig_lib_path: ?[]const u8) !ModuleGraph {
+pub fn init(io: std.Io, allocator: std.mem.Allocator, root_source: []const u8, zig_lib_path: ?[]const u8) !ModuleGraph {
     const root_dir = std.fs.path.dirname(root_source) orelse ".";
 
     var graph: ModuleGraph = .{
         .allocator = allocator,
+        .io = io,
         .zig_lib_path = zig_lib_path,
         .root_dir = root_dir,
         .modules = .empty,
@@ -54,18 +61,26 @@ pub fn addModulePublic(self: *ModuleGraph, path: []const u8) void {
 }
 
 fn addModule(self: *ModuleGraph, path: []const u8) !void {
-    const canonical = try std.fs.cwd().realpathAlloc(self.allocator, path);
+    // `realPathFileAlloc` returns a sentinel-terminated `[:0]u8` (allocated as
+    // `len + 1` bytes). We store the canonical path with its sentinel intact so
+    // the matching `free` later sees the same slice it was allocated as -- this
+    // is what avoids the "Allocation size N+1 vs free size N" debug-allocator
+    // panic. The graph owns this buffer for its lifetime; it is freed in
+    // `deinit`. No extra `dupe` is needed (the previous code did one purely to
+    // strip the sentinel for typing reasons).
+    const canonical: [:0]const u8 = try std.Io.Dir.cwd().realPathFileAlloc(self.io, path, self.allocator);
+    errdefer self.allocator.free(canonical);
 
     if (self.modules.contains(canonical)) {
         self.allocator.free(canonical);
         return;
     }
 
-    const source = std.fs.cwd().readFileAllocOptions(
-        self.allocator,
+    const source = std.Io.Dir.cwd().readFileAllocOptions(
+        self.io,
         canonical,
-        1024 * 1024 * 16,
-        null,
+        self.allocator,
+        .limited(1024 * 1024 * 16),
         .@"1",
         0,
     ) catch |err| {
@@ -234,7 +249,13 @@ pub fn moduleCount(self: *const ModuleGraph) usize {
 }
 
 pub fn getModule(self: *const ModuleGraph, path: []const u8) ?*const Module {
-    const canonical = std.fs.cwd().realpathAlloc(self.allocator, path) catch return null;
+    // Fast path: most callers pass paths that came from this graph (already canonical).
+    // This also avoids a Zig 0.16 stdlib SIMD bug in containsAtLeastScalar2 that can
+    // segfault on certain short paths inside realPathFileAlloc.
+    if (self.modules.getPtr(path)) |mod| return mod;
+
+    // Fallback: canonicalize via realpath for uncanonical inputs.
+    const canonical = std.Io.Dir.cwd().realPathFileAlloc(self.io, path, self.allocator) catch return null;
     defer self.allocator.free(canonical);
     return self.modules.getPtr(canonical);
 }
@@ -248,6 +269,12 @@ pub fn zirCount(self: *const ModuleGraph) usize {
     return count;
 }
 
+/// Test-only Io provider. Tests are synchronous and don't need cancelation,
+/// so we use the global single-threaded Io instance.
+fn testIo() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
 test "parse simple module" {
     const source =
         \\const std = @import("std");
@@ -258,12 +285,13 @@ test "parse simple module" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "main.zig", .data = source });
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "main.zig", .data = source });
 
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "main.zig");
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "main.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     try std.testing.expectEqual(1, graph.moduleCount());
@@ -273,13 +301,14 @@ test "resolve relative import" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "main.zig", .data = "const utils = @import(\"utils.zig\");" });
-    try tmp_dir.dir.writeFile(.{ .sub_path = "utils.zig", .data = "pub fn helper() void {}" });
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "main.zig", .data = "const utils = @import(\"utils.zig\");" });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "utils.zig", .data = "pub fn helper() void {}" });
 
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "main.zig");
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "main.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     try std.testing.expectEqual(2, graph.moduleCount());
@@ -289,12 +318,13 @@ test "handle missing import gracefully" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "main.zig", .data = "const missing = @import(\"nonexistent.zig\");" });
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "main.zig", .data = "const missing = @import(\"nonexistent.zig\");" });
 
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "main.zig");
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "main.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     try std.testing.expectEqual(1, graph.moduleCount());
@@ -304,17 +334,18 @@ test "no duplicate modules" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "main.zig", .data = 
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "main.zig", .data =
         \\const a = @import("shared.zig");
         \\const b = @import("other.zig");
     });
-    try tmp_dir.dir.writeFile(.{ .sub_path = "other.zig", .data = "const shared = @import(\"shared.zig\");" });
-    try tmp_dir.dir.writeFile(.{ .sub_path = "shared.zig", .data = "pub const x = 1;" });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "other.zig", .data = "const shared = @import(\"shared.zig\");" });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "shared.zig", .data = "pub const x = 1;" });
 
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "main.zig");
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "main.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     // main.zig, other.zig, shared.zig - no duplicates

--- a/src/ModuleGraph.zig
+++ b/src/ModuleGraph.zig
@@ -28,7 +28,7 @@ pub const Module = struct {
     zir: ?Zir = null,
 };
 
-pub fn init(io: std.Io, allocator: std.mem.Allocator, root_source: []const u8, zig_lib_path: ?[]const u8) !ModuleGraph {
+pub fn init(allocator: std.mem.Allocator, io: std.Io, root_source: []const u8, zig_lib_path: ?[]const u8) !ModuleGraph {
     const root_dir = std.fs.path.dirname(root_source) orelse ".";
 
     var graph: ModuleGraph = .{
@@ -291,7 +291,7 @@ test "parse simple module" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "main.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     try std.testing.expectEqual(1, graph.moduleCount());
@@ -308,7 +308,7 @@ test "resolve relative import" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "main.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     try std.testing.expectEqual(2, graph.moduleCount());
@@ -324,7 +324,7 @@ test "handle missing import gracefully" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "main.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     try std.testing.expectEqual(1, graph.moduleCount());
@@ -345,7 +345,7 @@ test "no duplicate modules" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "main.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     // main.zig, other.zig, shared.zig - no duplicates

--- a/src/TypeResolver.zig
+++ b/src/TypeResolver.zig
@@ -1139,10 +1139,18 @@ fn resolveNumberLiteral(_: *TypeResolver, tree: *const Ast, node: Ast.Node.Index
 }
 
 fn nodeIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, module_path: []const u8) bool {
+    return self.nodeIsTypeRefDepth(tree, node, module_path, 0);
+}
+
+fn nodeIsTypeRefDepth(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, module_path: []const u8, depth: u32) bool {
+    // Cyclic aliases (`const a = b; const b = a;`) would otherwise recurse
+    // unbounded through varDeclIsTypeRef/identifierIsTypeRef. ziglint analyzes
+    // untrusted source, so bound the alias chain like findMethodInFileAsStruct.
+    if (depth >= max_alias_depth) return false;
     return switch (tree.nodeTag(node)) {
-        .simple_var_decl, .aligned_var_decl, .local_var_decl, .global_var_decl => self.varDeclIsTypeRef(tree, node, module_path),
-        .identifier => self.identifierIsTypeRef(tree, node, module_path),
-        .field_access => self.fieldAccessIsTypeRef(tree, node, module_path),
+        .simple_var_decl, .aligned_var_decl, .local_var_decl, .global_var_decl => self.varDeclIsTypeRef(tree, node, module_path, depth),
+        .identifier => self.identifierIsTypeRef(tree, node, module_path, depth),
+        .field_access => self.fieldAccessIsTypeRef(tree, node, module_path, depth),
         .builtin_call_two, .builtin_call_two_comma => self.builtinCallIsTypeRef(tree, node),
         .container_decl,
         .container_decl_trailing,
@@ -1167,7 +1175,7 @@ fn nodeIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, mo
     };
 }
 
-fn varDeclIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, module_path: []const u8) bool {
+fn varDeclIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, module_path: []const u8, depth: u32) bool {
     const var_decl = tree.fullVarDecl(node) orelse return false;
     if (var_decl.ast.type_node.unwrap()) |type_node| {
         if (tree.nodeTag(type_node) == .identifier) {
@@ -1176,10 +1184,10 @@ fn varDeclIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index,
         return false;
     }
     const init_node = var_decl.ast.init_node.unwrap() orelse return false;
-    return self.nodeIsTypeRef(tree, init_node, module_path);
+    return self.nodeIsTypeRefDepth(tree, init_node, module_path, depth + 1);
 }
 
-fn identifierIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, module_path: []const u8) bool {
+fn identifierIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, module_path: []const u8, depth: u32) bool {
     const name = tree.tokenSlice(tree.nodeMainToken(node));
     if (resolvePrimitiveType(name) != null) return true;
     if (std.mem.eql(u8, name, "type")) return true;
@@ -1189,7 +1197,7 @@ fn identifierIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Ind
                 const var_decl = tree.fullVarDecl(decl_node) orelse continue;
                 const name_token = var_decl.ast.mut_token + 1;
                 if (!std.mem.eql(u8, tree.tokenSlice(name_token), name)) continue;
-                return self.varDeclIsTypeRef(tree, decl_node, module_path);
+                return self.varDeclIsTypeRef(tree, decl_node, module_path, depth + 1);
             },
             else => {},
         }
@@ -1197,9 +1205,9 @@ fn identifierIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Ind
     return false;
 }
 
-fn fieldAccessIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, module_path: []const u8) bool {
+fn fieldAccessIsTypeRef(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Index, module_path: []const u8, depth: u32) bool {
     const data = tree.nodeData(node).node_and_token;
-    if (!self.nodeIsTypeRef(tree, data[0], module_path)) return false;
+    if (!self.nodeIsTypeRefDepth(tree, data[0], module_path, depth + 1)) return false;
     const type_info = self.resolveFieldAccess(tree, node, module_path);
     return switch (type_info) {
         .std_type, .user_type, .type_type => true,
@@ -2059,4 +2067,87 @@ test "findFnInCurrentModule: const alias to function" {
     defer if (doc) |d| std.testing.allocator.free(d);
     try std.testing.expect(doc != null);
     try std.testing.expect(std.mem.find(u8, doc.?, "Deprecated") != null);
+}
+
+test "findFnInCurrentModule: cyclic method alias terminates via max_alias_depth" {
+    // Exercises the depth guard in findMethodInFileAsStructDepth: a cyclic
+    // method-alias chain must return null instead of recursing unbounded.
+    const source =
+        \\pub const aliasA = aliasB;
+        \\pub const aliasB = aliasA;
+    ;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
+    defer std.testing.allocator.free(path);
+
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
+    defer graph.deinit();
+
+    var resolver: TypeResolver = .init(std.testing.allocator, &graph);
+    defer resolver.deinit();
+
+    // Must terminate (not stack-overflow) and find no concrete function.
+    const method_def = resolver.findFnInCurrentModule(path, "aliasA");
+    try std.testing.expect(method_def == null);
+}
+
+test "isTypeRef: cyclic alias terminates without stack overflow" {
+    // A linter analyzes untrusted source, so a cyclic alias must not recurse
+    // unbounded through nodeIsTypeRef -> identifierIsTypeRef -> varDeclIsTypeRef.
+    const source =
+        \\const a = b;
+        \\const b = a;
+    ;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
+    defer std.testing.allocator.free(path);
+
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
+    defer graph.deinit();
+
+    var resolver: TypeResolver = .init(std.testing.allocator, &graph);
+    defer resolver.deinit();
+
+    const mod = graph.getModule(path).?;
+    const root_decls = mod.tree.rootDecls();
+    const var_decl = mod.tree.fullVarDecl(root_decls[0]).?;
+    const init_node = var_decl.ast.init_node.unwrap().?;
+    // Must return (not crash) and report not-a-type, since the cycle resolves to nothing.
+    try std.testing.expect(!resolver.isTypeRef(path, init_node));
+}
+
+test "isTypeRef: self-referential alias terminates without stack overflow" {
+    const source =
+        \\const a = a;
+    ;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
+    defer std.testing.allocator.free(path);
+
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
+    defer graph.deinit();
+
+    var resolver: TypeResolver = .init(std.testing.allocator, &graph);
+    defer resolver.deinit();
+
+    const mod = graph.getModule(path).?;
+    const root_decls = mod.tree.rootDecls();
+    const var_decl = mod.tree.fullVarDecl(root_decls[0]).?;
+    const init_node = var_decl.ast.init_node.unwrap().?;
+    try std.testing.expect(!resolver.isTypeRef(path, init_node));
 }

--- a/src/TypeResolver.zig
+++ b/src/TypeResolver.zig
@@ -11,6 +11,12 @@ const ModuleGraph = @import("ModuleGraph.zig");
 
 const TypeResolver = @This();
 
+/// Test-only Io provider. Tests are synchronous and don't need cancelation,
+/// so we use the global single-threaded Io instance.
+fn testIo() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
 allocator: std.mem.Allocator,
 graph: *ModuleGraph,
 
@@ -440,11 +446,22 @@ fn findDeclInModule(self: *TypeResolver, tree: *const Ast, name: []const u8, mod
                         if (std.mem.endsWith(u8, import_str, ".zig")) {
                             const module_dir = std.fs.path.dirname(module_path) orelse ".";
                             const resolved = std.fs.path.join(self.allocator, &.{ module_dir, import_str }) catch continue;
-                            const canonical = std.fs.cwd().realpathAlloc(self.allocator, resolved) catch {
+                            // `realPathFileAlloc` returns a sentinel-terminated `[:0]u8`
+                            // (allocated `len + 1`). We dupe into a plain `[]u8` so the
+                            // returned `DeclResult.import_path` type-matches the non-sentinel
+                            // sibling (`current_module_path`) used by callers, which uniformly
+                            // free the slice with the same length they received -- avoiding the
+                            // sentinel/non-sentinel size mismatch in DebugAllocator.
+                            const canonical_z = std.Io.Dir.cwd().realPathFileAlloc(self.graph.io, resolved, self.allocator) catch {
                                 self.allocator.free(resolved);
                                 continue;
                             };
                             self.allocator.free(resolved);
+                            const canonical = self.allocator.dupe(u8, canonical_z) catch {
+                                self.allocator.free(canonical_z);
+                                continue;
+                            };
+                            self.allocator.free(canonical_z);
                             return .{ .import_path = canonical };
                         }
                     }
@@ -468,7 +485,10 @@ fn findMethodInModule(self: *TypeResolver, module_path: []const u8, type_name: [
 
     const type_node = self.findTypeDecl(tree, type_name) orelse return null;
 
-    return self.findMethodInType(tree, type_node, method_name, module_path);
+    // Use `mod.path` (owned by the graph for the lifetime of the resolver)
+    // rather than the input `module_path`, which may be a temporary slice
+    // freed by callers like `findMethodInStdlib` after they return.
+    return self.findMethodInType(tree, type_node, method_name, mod.path);
 }
 
 /// For file-as-struct modules (like fs/File.zig), look for methods in root declarations.
@@ -1189,11 +1209,12 @@ test "resolve primitive types" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1216,11 +1237,12 @@ test "resolve bool literal" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1241,11 +1263,12 @@ test "resolve import std" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1265,11 +1288,12 @@ test "resolve function returns type" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1289,11 +1313,12 @@ test "resolve number literal int" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1314,11 +1339,12 @@ test "resolve number literal float" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1342,11 +1368,12 @@ test "resolve field access on std" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1372,11 +1399,12 @@ test "resolve nested field access std.fs.File" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1402,11 +1430,12 @@ test "resolve field access on aliased std import" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1432,11 +1461,12 @@ test "resolve nested field access on aliased std import" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1459,11 +1489,12 @@ test "resolve string literal" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1483,11 +1514,12 @@ test "resolve function declaration" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1511,11 +1543,12 @@ test "find method in user type" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1538,11 +1571,12 @@ test "find method not found returns null" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1558,12 +1592,13 @@ test "find method in std_type without zig_lib_path returns null" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = "const x = 1;" });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = "const x = 1;" });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
     // No zig_lib_path, so stdlib can't be resolved
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1586,11 +1621,12 @@ test "resolve function call return type" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1613,11 +1649,12 @@ test "resolve function call returning bool" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1644,11 +1681,12 @@ test "resolve method call return type" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1671,11 +1709,12 @@ test "resolve type-returning function call" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1694,11 +1733,12 @@ test "resolve unknown function call" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1715,11 +1755,12 @@ test "isTypeRef: struct declaration" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1738,11 +1779,12 @@ test "isTypeRef: instance with type annotation" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1759,11 +1801,12 @@ test "isTypeRef: primitive typed variable" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1779,11 +1822,12 @@ test "isTypeRef: explicit type annotation" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1799,11 +1843,12 @@ test "isTypeRef: enum declaration" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1824,11 +1869,12 @@ test "isTypeRef: function call returning type" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1849,11 +1895,12 @@ test "isTypeRef: function call returning value" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1872,11 +1919,12 @@ test "isTypeRef: identifier resolving to struct" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1898,11 +1946,12 @@ test "isTypeRef: identifier resolving to instance" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1926,11 +1975,12 @@ test "findFnInCurrentModule: type function" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1949,11 +1999,12 @@ test "findFnInCurrentModule: direct function" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1973,11 +2024,12 @@ test "findFnInCurrentModule: const alias to function" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try tmp_dir.dir.writeFile(.{ .sub_path = "test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(std.testing.allocator, "test.zig");
+    const io = testIo();
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);

--- a/src/TypeResolver.zig
+++ b/src/TypeResolver.zig
@@ -1113,9 +1113,9 @@ fn resolveNumberLiteral(_: *TypeResolver, tree: *const Ast, node: Ast.Node.Index
     const main_token = tree.nodeMainToken(node);
     const text = tree.tokenSlice(main_token);
 
-    if (std.mem.indexOf(u8, text, ".") != null or
-        std.mem.indexOf(u8, text, "e") != null or
-        std.mem.indexOf(u8, text, "E") != null)
+    if (std.mem.find(u8, text, ".") != null or
+        std.mem.find(u8, text, "e") != null or
+        std.mem.find(u8, text, "E") != null)
     {
         return .{ .primitive = .comptime_float };
     }
@@ -1214,7 +1214,7 @@ test "resolve primitive types" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1242,7 +1242,7 @@ test "resolve bool literal" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1268,7 +1268,7 @@ test "resolve import std" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1293,7 +1293,7 @@ test "resolve function returns type" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1318,7 +1318,7 @@ test "resolve number literal int" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1344,7 +1344,7 @@ test "resolve number literal float" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1373,7 +1373,7 @@ test "resolve field access on std" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1404,7 +1404,7 @@ test "resolve nested field access std.fs.File" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1435,7 +1435,7 @@ test "resolve field access on aliased std import" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1466,7 +1466,7 @@ test "resolve nested field access on aliased std import" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1494,7 +1494,7 @@ test "resolve string literal" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1519,7 +1519,7 @@ test "resolve function declaration" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1548,7 +1548,7 @@ test "find method in user type" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1576,7 +1576,7 @@ test "find method not found returns null" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1598,7 +1598,7 @@ test "find method in std_type without zig_lib_path returns null" {
     defer std.testing.allocator.free(path);
 
     // No zig_lib_path, so stdlib can't be resolved
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1626,7 +1626,7 @@ test "resolve function call return type" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1654,7 +1654,7 @@ test "resolve function call returning bool" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1686,7 +1686,7 @@ test "resolve method call return type" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1714,7 +1714,7 @@ test "resolve type-returning function call" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1738,7 +1738,7 @@ test "resolve unknown function call" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1760,7 +1760,7 @@ test "isTypeRef: struct declaration" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1784,7 +1784,7 @@ test "isTypeRef: instance with type annotation" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1806,7 +1806,7 @@ test "isTypeRef: primitive typed variable" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1827,7 +1827,7 @@ test "isTypeRef: explicit type annotation" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1848,7 +1848,7 @@ test "isTypeRef: enum declaration" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1874,7 +1874,7 @@ test "isTypeRef: function call returning type" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1900,7 +1900,7 @@ test "isTypeRef: function call returning value" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1924,7 +1924,7 @@ test "isTypeRef: identifier resolving to struct" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1951,7 +1951,7 @@ test "isTypeRef: identifier resolving to instance" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -1980,7 +1980,7 @@ test "findFnInCurrentModule: type function" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -2004,7 +2004,7 @@ test "findFnInCurrentModule: direct function" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -2029,7 +2029,7 @@ test "findFnInCurrentModule: const alias to function" {
     const path = try tmp_dir.dir.realPathFileAlloc(io, "test.zig", std.testing.allocator);
     defer std.testing.allocator.free(path);
 
-    var graph = try ModuleGraph.init(io, std.testing.allocator, path, null);
+    var graph = try ModuleGraph.init(std.testing.allocator, io, path, null);
     defer graph.deinit();
 
     var resolver: TypeResolver = .init(std.testing.allocator, &graph);
@@ -2043,5 +2043,5 @@ test "findFnInCurrentModule: const alias to function" {
     const doc = doc_comments.getDocComment(std.testing.allocator, &mod.tree, method_def.?.node);
     defer if (doc) |d| std.testing.allocator.free(d);
     try std.testing.expect(doc != null);
-    try std.testing.expect(std.mem.indexOf(u8, doc.?, "Deprecated") != null);
+    try std.testing.expect(std.mem.find(u8, doc.?, "Deprecated") != null);
 }

--- a/src/TypeResolver.zig
+++ b/src/TypeResolver.zig
@@ -491,8 +491,22 @@ fn findMethodInModule(self: *TypeResolver, module_path: []const u8, type_name: [
     return self.findMethodInType(tree, type_node, method_name, mod.path);
 }
 
+/// Alias chains (`const a = b;`) are followed at most this many hops so
+/// cyclic aliases (`const a = b; const b = a;`) cannot recurse unbounded.
+const max_alias_depth: u32 = 32;
+
 /// For file-as-struct modules (like fs/File.zig), look for methods in root declarations.
 fn findMethodInFileAsStruct(self: *TypeResolver, module_path: []const u8, method_name: []const u8) ?MethodDef {
+    return self.findMethodInFileAsStructDepth(module_path, method_name, 0);
+}
+
+fn findMethodInFileAsStructDepth(
+    self: *TypeResolver,
+    module_path: []const u8,
+    method_name: []const u8,
+    depth: u32,
+) ?MethodDef {
+    if (depth >= max_alias_depth) return null;
     self.graph.addModulePublic(module_path);
     const mod = self.graph.getModule(module_path) orelse return null;
     const tree = &mod.tree;
@@ -530,7 +544,7 @@ fn findMethodInFileAsStruct(self: *TypeResolver, module_path: []const u8, method
                 // It's an alias like `const ArrayListUnmanaged = ArrayList;`
                 // Follow the alias to find the actual function
                 const alias_target = tree.tokenSlice(tree.nodeMainToken(init_node));
-                return self.findMethodInFileAsStruct(module_path, alias_target);
+                return self.findMethodInFileAsStructDepth(module_path, alias_target, depth + 1);
             } else if (init_tag == .fn_decl) {
                 // Inline function definition
                 var buf: [1]Ast.Node.Index = undefined;
@@ -822,9 +836,10 @@ fn resolveFieldAccess(self: *TypeResolver, tree: *const Ast, node: Ast.Node.Inde
             return .{ .std_type = .{ .path = full_path } };
         },
         .user_type => {
-            // Accessing a field on a user type - could be a nested type
-            const full_path = self.buildStdTypePath(tree, node);
-            return .{ .std_type = .{ .path = full_path } };
+            // A field access on a user-defined type is not a stdlib type.
+            // Coercing it into `.std_type` conflated user namespaces with
+            // `std` ones and misrouted downstream semantic resolution.
+            return .unknown;
         },
         .unknown => {
             const lhs_tag = tree.nodeTag(lhs_node);

--- a/src/doc_comments.zig
+++ b/src/doc_comments.zig
@@ -23,8 +23,21 @@ pub fn getDocComment(allocator: std.mem.Allocator, tree: *const Ast, node: Ast.N
         if (tag == .doc_comment) {
             doc_tokens.append(allocator, token) catch return null;
         } else {
-            // Stop at non-doc-comment tokens (skip pub keyword)
-            if (tag != .keyword_pub) break;
+            // Stop at non-doc-comment tokens, skipping declaration
+            // qualifiers (`pub inline fn`, `pub extern "c" fn`, ...) that
+            // may sit between the doc comment and the declaration itself.
+            switch (tag) {
+                .keyword_pub,
+                .keyword_inline,
+                .keyword_noinline,
+                .keyword_extern,
+                .keyword_export,
+                .keyword_threadlocal,
+                .keyword_comptime,
+                .string_literal,
+                => {},
+                else => break,
+            }
         }
         if (token == 0) break;
         token -= 1;

--- a/src/doc_tests.zig
+++ b/src/doc_tests.zig
@@ -12,6 +12,12 @@ const ModuleGraph = @import("ModuleGraph.zig");
 const TypeResolver = @import("TypeResolver.zig");
 const rules = @import("rules.zig");
 
+/// Test-only Io provider. Tests are synchronous and don't need cancelation,
+/// so we use the global single-threaded Io instance.
+fn testIo() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
 const DocTest = struct {
     code: []const u8,
     expected_rules: []const rules.Rule,
@@ -98,13 +104,14 @@ fn runDocTest(allocator: std.mem.Allocator, doc_path: []const u8, doc_test: DocT
     defer allocator.free(source);
     @memcpy(source, doc_test.code);
 
+    const io = testIo();
     // Write to temp file for semantic analysis
-    try tmp_dir.dir.writeFile(.{ .sub_path = "doc_test.zig", .data = source });
-    const path = try tmp_dir.dir.realpathAlloc(allocator, "doc_test.zig");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "doc_test.zig", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(io, "doc_test.zig", allocator);
     defer allocator.free(path);
 
     // Try to create ModuleGraph for semantic analysis (may fail for invalid code)
-    var graph: ?ModuleGraph = ModuleGraph.init(allocator, path, null) catch null;
+    var graph: ?ModuleGraph = ModuleGraph.init(io, allocator, path, null) catch null;
     defer if (graph) |*g| g.deinit();
 
     var resolver: ?TypeResolver = if (graph) |*g| TypeResolver.init(allocator, g) else null;
@@ -150,16 +157,17 @@ fn runDocTest(allocator: std.mem.Allocator, doc_path: []const u8, doc_test: DocT
 }
 
 pub fn runAllDocTests(allocator: std.mem.Allocator) !void {
+    const io = testIo();
     // Open docs/rules directory
     const docs_path = "docs/rules";
-    var dir = std.fs.cwd().openDir(docs_path, .{ .iterate = true }) catch |err| {
+    var dir = std.Io.Dir.cwd().openDir(io, docs_path, .{ .iterate = true }) catch |err| {
         if (err == error.FileNotFound) {
             std.debug.print("No docs/rules directory found, skipping doc tests\n", .{});
             return;
         }
         return err;
     };
-    defer dir.close();
+    defer dir.close(io);
 
     // Create temp directory for semantic analysis
     var tmp_dir = std.testing.tmpDir(.{});
@@ -168,14 +176,11 @@ pub fn runAllDocTests(allocator: std.mem.Allocator) !void {
     var file_count: usize = 0;
     var test_count: usize = 0;
     var iter = dir.iterate();
-    while (try iter.next()) |entry| {
+    while (try iter.next(io)) |entry| {
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.name, ".md")) continue;
 
-        const file = try dir.openFile(entry.name, .{});
-        defer file.close();
-
-        const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+        const content = try dir.readFileAlloc(io, entry.name, allocator, .limited(1024 * 1024));
         defer allocator.free(content);
 
         const doc = try parseMarkdown(allocator, content);

--- a/src/doc_tests.zig
+++ b/src/doc_tests.zig
@@ -138,19 +138,21 @@ fn runDocTest(allocator: std.mem.Allocator, doc_path: []const u8, doc_test: DocT
         }
     }
 
-    // If no expectations, should have no diagnostics
-    if (doc_test.expected_rules.len == 0) {
-        const total = linter.diagnostics.items.len;
-        if (total > 0) {
-            std.debug.print("\n{s}:{d}: expected no diagnostics but got {d}\n", .{
+    // Reject diagnostics for rules that were not expected. Extra findings
+    // must not ride along silently just because one expectation matched —
+    // and with no expectations at all, any diagnostic is unexpected.
+    for (linter.diagnostics.items) |d| {
+        const expected = for (doc_test.expected_rules) |expected_rule| {
+            if (expected_rule == d.rule) break true;
+        } else false;
+        if (!expected) {
+            std.debug.print("\n{s}:{d}: unexpected {s} diagnostic: {s}\n", .{
                 doc_path,
                 doc_test.line_in_doc,
-                total,
+                d.rule.code(),
+                d.context,
             });
             std.debug.print("Code:\n{s}\n", .{doc_test.code});
-            for (linter.diagnostics.items) |d| {
-                std.debug.print("  - {s}: {s}\n", .{ d.rule.code(), d.context });
-            }
             return error.UnexpectedDiagnostic;
         }
     }
@@ -175,6 +177,7 @@ pub fn runAllDocTests(allocator: std.mem.Allocator) !void {
 
     var file_count: usize = 0;
     var test_count: usize = 0;
+    var failure_count: usize = 0;
     var iter = dir.iterate();
     while (try iter.next(io)) |entry| {
         if (entry.kind != .file) continue;
@@ -193,10 +196,24 @@ pub fn runAllDocTests(allocator: std.mem.Allocator) !void {
         defer allocator.free(full_path);
 
         for (doc.tests) |doc_test| {
-            try runDocTest(allocator, full_path, doc_test, &tmp_dir);
+            // Run every fixture before failing so one gate run reports all
+            // offending docs instead of stopping at the first. Only the two
+            // assertion errors count as fixture failures; infrastructure
+            // errors (I/O, OOM, ...) propagate immediately.
+            runDocTest(allocator, full_path, doc_test, &tmp_dir) catch |err| switch (err) {
+                error.MissingExpectedDiagnostic,
+                error.UnexpectedDiagnostic,
+                => failure_count += 1,
+                else => return err,
+            };
             test_count += 1;
         }
         file_count += 1;
+    }
+
+    if (failure_count > 0) {
+        std.debug.print("\n{d}/{d} doc tests failed\n", .{ failure_count, test_count });
+        return error.DocTestsFailed;
     }
 }
 

--- a/src/doc_tests.zig
+++ b/src/doc_tests.zig
@@ -36,7 +36,7 @@ fn parseMarkdown(allocator: std.mem.Allocator, content: []const u8) !ParsedDoc {
 
     // Parse frontmatter for rule identifier
     if (std.mem.startsWith(u8, content, "---\n")) {
-        if (std.mem.indexOf(u8, content[4..], "\n---")) |end| {
+        if (std.mem.find(u8, content[4..], "\n---")) |end| {
             const frontmatter = content[4..][0..end];
             var lines = std.mem.splitScalar(u8, frontmatter, '\n');
             while (lines.next()) |line| {
@@ -51,7 +51,7 @@ fn parseMarkdown(allocator: std.mem.Allocator, content: []const u8) !ParsedDoc {
     // Find all zig code blocks
     var line_num: usize = 1;
     var pos: usize = 0;
-    while (std.mem.indexOfPos(u8, content, pos, "```zig\n")) |start| {
+    while (std.mem.findPos(u8, content, pos, "```zig\n")) |start| {
         // Count lines up to this point
         for (content[pos..start]) |c| {
             if (c == '\n') line_num += 1;
@@ -59,14 +59,14 @@ fn parseMarkdown(allocator: std.mem.Allocator, content: []const u8) !ParsedDoc {
         line_num += 1; // for the ```zig line
 
         const code_start = start + 7;
-        if (std.mem.indexOfPos(u8, content, code_start, "\n```")) |end| {
+        if (std.mem.findPos(u8, content, code_start, "\n```")) |end| {
             const code = content[code_start..end];
 
             // Parse expected rules from `// expect: ZXXX` comments
             var expected: std.ArrayList(rules.Rule) = .empty;
             var code_lines = std.mem.splitScalar(u8, code, '\n');
             while (code_lines.next()) |code_line| {
-                if (std.mem.indexOf(u8, code_line, "// expect:")) |expect_pos| {
+                if (std.mem.find(u8, code_line, "// expect:")) |expect_pos| {
                     var expect_str = code_line[expect_pos + 10 ..];
                     expect_str = std.mem.trim(u8, expect_str, " ");
                     // Handle multiple expectations: `// expect: Z001, Z002`
@@ -111,7 +111,7 @@ fn runDocTest(allocator: std.mem.Allocator, doc_path: []const u8, doc_test: DocT
     defer allocator.free(path);
 
     // Try to create ModuleGraph for semantic analysis (may fail for invalid code)
-    var graph: ?ModuleGraph = ModuleGraph.init(io, allocator, path, null) catch null;
+    var graph: ?ModuleGraph = ModuleGraph.init(allocator, io, path, null) catch null;
     defer if (graph) |*g| g.deinit();
 
     var resolver: ?TypeResolver = if (graph) |*g| TypeResolver.init(allocator, g) else null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,7 +1,6 @@
 //! ziglint - A linter for Zig source code
 
 const std = @import("std");
-const builtin = @import("builtin");
 const build_options = @import("build_options");
 pub const version = build_options.version;
 
@@ -49,7 +48,7 @@ pub fn main(init: std.process.Init) !u8 {
     const cfg_alloc = config_arena.allocator();
 
     const stderr_file = std.Io.File.stderr();
-    const use_color = detectColorSupport(stderr_file, io, environ_map);
+    const use_color = detectColorSupport(io, stderr_file, environ_map);
 
     var stdout_buf: [4096]u8 = undefined;
     var stdout = std.Io.File.stdout().writer(io, &stdout_buf);
@@ -67,7 +66,7 @@ pub fn main(init: std.process.Init) !u8 {
 
     // Load config file from first CLI path (or current directory)
     const start_path = if (config.paths.len > 0) config.paths[0] else null;
-    config.file_config = FileConfig.load(io, cfg_alloc, start_path) catch .{};
+    config.file_config = FileConfig.load(cfg_alloc, io, start_path) catch .{};
 
     applyOnlyRules(&config);
 
@@ -106,7 +105,7 @@ pub fn main(init: std.process.Init) !u8 {
     return if (total_issues > 0) 1 else 0;
 }
 
-fn detectColorSupport(file: std.Io.File, io: std.Io, environ_map: *const std.process.Environ.Map) bool {
+fn detectColorSupport(io: std.Io, file: std.Io.File, environ_map: *const std.process.Environ.Map) bool {
     // NO_COLOR takes precedence (https://no-color.org/)
     if (environ_map.get("NO_COLOR")) |_| return false;
     if (environ_map.get("FORCE_COLOR")) |_| return true;
@@ -261,9 +260,9 @@ fn detectZigLibPath(out_alloc: std.mem.Allocator, tmp_alloc: std.mem.Allocator, 
 
 fn parseLibDirFromZigEnv(allocator: std.mem.Allocator, output: []const u8) ?[]const u8 {
     const needle = ".lib_dir = \"";
-    const start_idx = std.mem.indexOf(u8, output, needle) orelse return null;
+    const start_idx = std.mem.find(u8, output, needle) orelse return null;
     const value_start = start_idx + needle.len;
-    const end_idx = std.mem.indexOfPos(u8, output, value_start, "\"") orelse return null;
+    const end_idx = std.mem.findPos(u8, output, value_start, "\"") orelse return null;
     return allocator.dupe(u8, output[value_start..end_idx]) catch null;
 }
 
@@ -290,7 +289,7 @@ fn lintDirectory(allocator: std.mem.Allocator, io: std.Io, path: []const u8, zig
     };
     defer dir.close(io);
 
-    const gitignore = loadGitignore(io, allocator, dir);
+    const gitignore = loadGitignore(allocator, io, dir);
     defer if (gitignore) |g| allocator.free(g);
 
     // Collect all .zig files first
@@ -332,7 +331,7 @@ fn lintDirectory(allocator: std.mem.Allocator, io: std.Io, path: []const u8, zig
 
     // Build module graph once using first file as root, then add all others
     const graph_start = if (timer) |*t| t.read(io) else 0;
-    var graph = ModuleGraph.init(io, allocator, files.items[0], zig_lib_path) catch {
+    var graph = ModuleGraph.init(allocator, io, files.items[0], zig_lib_path) catch {
         // Fall back to per-file linting without semantics
         if (config.verbose) {
             try writer.print("{s}│ module graph failed, using simple linting{s}\n", .{ dim, reset });
@@ -418,10 +417,10 @@ fn matchesGitignore(path: []const u8, pattern: []const u8) bool {
         if (std.mem.eql(u8, component, clean_pattern)) return true;
     }
 
-    return std.mem.indexOf(u8, path, clean_pattern) != null;
+    return std.mem.find(u8, path, clean_pattern) != null;
 }
 
-fn loadGitignore(io: std.Io, allocator: std.mem.Allocator, dir: std.Io.Dir) ?[]const u8 {
+fn loadGitignore(allocator: std.mem.Allocator, io: std.Io, dir: std.Io.Dir) ?[]const u8 {
     return dir.readFileAlloc(io, ".gitignore", allocator, .limited(1024 * 64)) catch null;
 }
 
@@ -437,7 +436,7 @@ fn lintFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, zig_lib_
     }
 
     const graph_start = if (timer) |*t| t.read(io) else 0;
-    var graph = ModuleGraph.init(io, allocator, path, zig_lib_path) catch {
+    var graph = ModuleGraph.init(allocator, io, path, zig_lib_path) catch {
         return lintFileSimple(allocator, io, path, config, use_color, project_root, writer);
     };
     defer graph.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -20,23 +20,46 @@ pub const Config = struct {
     verbose: bool = false,
 };
 
-pub fn main() !u8 {
-    var arena: std.heap.ArenaAllocator = .init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+/// Compatibility shim for the removed std.time.Timer in Zig 0.16.
+/// Wraps std.Io.Timestamp + monotonic clock with a Timer-like read() interface.
+const VerboseTimer = struct {
+    start: std.Io.Timestamp,
 
-    const stderr_file = std.fs.File.stderr();
-    const use_color = detectColorSupport(stderr_file);
+    fn init(io: std.Io) VerboseTimer {
+        return .{ .start = std.Io.Timestamp.now(io, .awake) };
+    }
+
+    fn read(self: *VerboseTimer, io: std.Io) u64 {
+        const elapsed = self.start.durationTo(std.Io.Timestamp.now(io, .awake));
+        return @intCast(@max(elapsed.nanoseconds, 0));
+    }
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    const allocator = init.gpa;
+    const io = init.io;
+    const environ_map = init.environ_map;
+
+    // Process-lifetime arena for CLI paths, detected `zig env` lib dir, and
+    // FileConfig dupes. These all live until end-of-main, so an arena is the
+    // simplest leak-free pattern (avoids hand-tracking individual frees in
+    // the catch/return paths).
+    var config_arena: std.heap.ArenaAllocator = .init(allocator);
+    defer config_arena.deinit();
+    const cfg_alloc = config_arena.allocator();
+
+    const stderr_file = std.Io.File.stderr();
+    const use_color = detectColorSupport(stderr_file, io, environ_map);
 
     var stdout_buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&stdout_buf);
+    var stdout = std.Io.File.stdout().writer(io, &stdout_buf);
     defer stdout.end() catch {};
 
     var stderr_buf: [4096]u8 = undefined;
-    var stderr = stderr_file.writer(&stderr_buf);
+    var stderr = stderr_file.writer(io, &stderr_buf);
     defer stderr.end() catch {};
 
-    var config = parseArgs(allocator, &stderr.interface) catch |err| switch (err) {
+    var config = parseArgs(cfg_alloc, init.minimal.args, &stderr.interface) catch |err| switch (err) {
         error.HelpOrVersion => return 0,
         error.InvalidArgs => return 1,
         else => return err,
@@ -44,7 +67,7 @@ pub fn main() !u8 {
 
     // Load config file from first CLI path (or current directory)
     const start_path = if (config.paths.len > 0) config.paths[0] else null;
-    config.file_config = FileConfig.load(allocator, start_path) catch .{};
+    config.file_config = FileConfig.load(io, cfg_alloc, start_path) catch .{};
 
     applyOnlyRules(&config);
 
@@ -57,19 +80,23 @@ pub fn main() !u8 {
         }
     }
 
-    const zig_lib_path = config.zig_lib_path orelse detectZigLibPath(allocator, &stderr.interface) catch null;
+    const zig_lib_path = config.zig_lib_path orelse detectZigLibPath(cfg_alloc, allocator, io, &stderr.interface) catch null;
 
-    var total_timer = if (config.verbose) std.time.Timer.start() catch null else null;
+    var total_timer = if (config.verbose) VerboseTimer.init(io) else null;
 
     var total_issues: usize = 0;
     for (config.paths) |path| {
-        const abs_path = std.fs.cwd().realpathAlloc(allocator, path) catch path;
-        const project_root = findProjectRoot(abs_path);
-        total_issues += try lintPath(allocator, path, zig_lib_path, &config, use_color, project_root, &stderr.interface);
+        const abs_path_z = std.Io.Dir.cwd().realPathFileAlloc(io, path, allocator) catch null;
+        defer if (abs_path_z) |p| allocator.free(p);
+        const abs_path: []const u8 = if (abs_path_z) |p| p else path;
+        // `project_root` is allocated from the process-lifetime arena (`cfg_alloc`)
+        // so it lives until end-of-main without a manual free.
+        const project_root = findProjectRoot(cfg_alloc, io, abs_path);
+        total_issues += try lintPath(allocator, io, path, zig_lib_path, &config, use_color, project_root, &stderr.interface);
     }
 
     if (config.verbose and total_timer != null) {
-        const total_ms = @as(f64, @floatFromInt(total_timer.?.read())) / 1_000_000.0;
+        const total_ms = @as(f64, @floatFromInt(total_timer.?.read(io))) / 1_000_000.0;
         const dim = if (use_color) "\x1b[2m" else "";
         const cyan = if (use_color) "\x1b[36m" else "";
         const reset = if (use_color) "\x1b[0m" else "";
@@ -79,29 +106,26 @@ pub fn main() !u8 {
     return if (total_issues > 0) 1 else 0;
 }
 
-fn detectColorSupport(file: std.fs.File) bool {
-    const native = builtin.os.tag;
+fn detectColorSupport(file: std.Io.File, io: std.Io, environ_map: *const std.process.Environ.Map) bool {
     // NO_COLOR takes precedence (https://no-color.org/)
-    if (native == .windows) {
-        if (std.process.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("NO_COLOR"))) |_| return false;
-        if (std.process.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("FORCE_COLOR"))) |_| return true;
-    } else {
-        if (std.posix.getenv("NO_COLOR")) |_| return false;
-        if (std.posix.getenv("FORCE_COLOR")) |_| return true;
-    }
-    // Otherwise, use color if stdout is a TTY
-    return file.isTty();
+    if (environ_map.get("NO_COLOR")) |_| return false;
+    if (environ_map.get("FORCE_COLOR")) |_| return true;
+    // Otherwise, use color if the provided file (caller-selected stream, e.g. stderr) is a TTY
+    return file.isTty(io) catch false;
 }
 
-fn findProjectRoot(start_path: []const u8) ?[]const u8 {
+/// Walks upwards from `start_path` looking for a directory containing `build.zig`.
+/// The returned slice is owned by `allocator` (callers typically pass a process-lifetime
+/// arena). Returns `null` if no project root is found or on allocation/IO failure.
+fn findProjectRoot(allocator: std.mem.Allocator, io: std.Io, start_path: []const u8) ?[]const u8 {
     var path = start_path;
     while (true) {
         // Check if build.zig exists in this directory
-        const build_zig = std.fs.path.join(std.heap.page_allocator, &.{ path, "build.zig" }) catch return null;
-        defer std.heap.page_allocator.free(build_zig);
+        const build_zig = std.fs.path.join(allocator, &.{ path, "build.zig" }) catch return null;
+        defer allocator.free(build_zig);
 
-        if (std.fs.cwd().access(build_zig, .{})) |_| {
-            return std.heap.page_allocator.dupe(u8, path) catch null;
+        if (std.Io.Dir.cwd().access(io, build_zig, .{})) |_| {
+            return allocator.dupe(u8, path) catch null;
         } else |_| {}
 
         // Move up one directory
@@ -124,46 +148,45 @@ fn makeRelativePath(path: []const u8, project_root: ?[]const u8) []const u8 {
     return path;
 }
 
-fn parseArgs(allocator: std.mem.Allocator, writer: *std.Io.Writer) !Config {
-    const args = try std.process.argsAlloc(allocator);
+fn parseArgs(allocator: std.mem.Allocator, args: std.process.Args, writer: *std.Io.Writer) !Config {
+    var iter = try args.iterateAllocator(allocator);
+    defer iter.deinit();
 
     var config: Config = .{};
     var paths: std.ArrayList([]const u8) = .empty;
     var only_rules: std.ArrayList(rules.Rule) = .empty;
     var ignored_rules: std.ArrayList(rules.Rule) = .empty;
 
-    var i: usize = 1;
-    while (i < args.len) : (i += 1) {
-        const arg = args[i];
+    // Skip program name (argv[0])
+    _ = iter.skip();
+
+    while (iter.next()) |arg| {
         if (std.mem.eql(u8, arg, "--zig-lib-path")) {
-            i += 1;
-            if (i >= args.len) {
+            const next = iter.next() orelse {
                 try writer.writeAll("error: --zig-lib-path requires a path argument\n");
                 return error.InvalidArgs;
-            }
-            config.zig_lib_path = args[i];
+            };
+            config.zig_lib_path = try allocator.dupe(u8, next);
         } else if (std.mem.eql(u8, arg, "--only")) {
-            i += 1;
-            if (i >= args.len) {
+            const next = iter.next() orelse {
                 try writer.writeAll("error: --only requires a rule code (e.g., Z001)\n");
                 return error.InvalidArgs;
-            }
-            if (parseRuleCode(args[i])) |rule| {
+            };
+            if (parseRuleCode(next)) |rule| {
                 try only_rules.append(allocator, rule);
             } else {
-                try writer.print("error: unknown rule code '{s}'\n", .{args[i]});
+                try writer.print("error: unknown rule code '{s}'\n", .{next});
                 return error.InvalidArgs;
             }
         } else if (std.mem.eql(u8, arg, "--ignore")) {
-            i += 1;
-            if (i >= args.len) {
+            const next = iter.next() orelse {
                 try writer.writeAll("error: --ignore requires a rule code (e.g., Z001)\n");
                 return error.InvalidArgs;
-            }
-            if (parseRuleCode(args[i])) |rule| {
+            };
+            if (parseRuleCode(next)) |rule| {
                 try ignored_rules.append(allocator, rule);
             } else {
-                try writer.print("error: unknown rule code '{s}'\n", .{args[i]});
+                try writer.print("error: unknown rule code '{s}'\n", .{next});
                 return error.InvalidArgs;
             }
         } else if (std.mem.eql(u8, arg, "--verbose")) {
@@ -178,7 +201,7 @@ fn parseArgs(allocator: std.mem.Allocator, writer: *std.Io.Writer) !Config {
             try writer.print("error: unknown option '{s}'\n", .{arg});
             return error.InvalidArgs;
         } else {
-            try paths.append(allocator, arg);
+            try paths.append(allocator, try allocator.dupe(u8, arg));
         }
     }
 
@@ -215,28 +238,25 @@ fn applyOnlyRules(config: *Config) void {
     }
 }
 
-fn detectZigLibPath(allocator: std.mem.Allocator, writer: *std.Io.Writer) !?[]const u8 {
-    var child: std.process.Child = .init(&.{ "zig", "env" }, allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Ignore;
-
-    child.spawn() catch |err| {
+/// `out_alloc` owns the returned slice (process-lifetime arena);
+/// `tmp_alloc` owns the temporary `zig env` stdout/stderr buffers.
+fn detectZigLibPath(out_alloc: std.mem.Allocator, tmp_alloc: std.mem.Allocator, io: std.Io, writer: *std.Io.Writer) !?[]const u8 {
+    const result = std.process.run(tmp_alloc, io, .{
+        .argv = &.{ "zig", "env" },
+        .stdout_limit = .limited(64 * 1024),
+    }) catch |err| {
         try writer.print("warning: could not run 'zig env': {}\n", .{err});
         return null;
     };
+    defer tmp_alloc.free(result.stdout);
+    defer tmp_alloc.free(result.stderr);
 
-    var buf: [64 * 1024]u8 = undefined;
-    const stdout = child.stdout orelse return null;
-    const len = stdout.readAll(&buf) catch return null;
-    const output = buf[0..len];
-
-    const term = child.wait() catch return null;
-    switch (term) {
-        .Exited => |code| if (code != 0) return null,
+    switch (result.term) {
+        .exited => |code| if (code != 0) return null,
         else => return null,
     }
 
-    return parseLibDirFromZigEnv(allocator, output);
+    return parseLibDirFromZigEnv(out_alloc, result.stdout);
 }
 
 fn parseLibDirFromZigEnv(allocator: std.mem.Allocator, output: []const u8) ?[]const u8 {
@@ -247,30 +267,30 @@ fn parseLibDirFromZigEnv(allocator: std.mem.Allocator, output: []const u8) ?[]co
     return allocator.dupe(u8, output[value_start..end_idx]) catch null;
 }
 
-fn lintPath(allocator: std.mem.Allocator, path: []const u8, zig_lib_path: ?[]const u8, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
-    const stat = std.fs.cwd().statFile(path) catch |err| {
+fn lintPath(allocator: std.mem.Allocator, io: std.Io, path: []const u8, zig_lib_path: ?[]const u8, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
+    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch |err| {
         if (err == error.IsDir) {
-            return lintDirectory(allocator, path, zig_lib_path, config, use_color, project_root, writer);
+            return lintDirectory(allocator, io, path, zig_lib_path, config, use_color, project_root, writer);
         }
         try writer.print("error: cannot access '{s}': {}\n", .{ path, err });
         return 0;
     };
 
     if (stat.kind == .directory) {
-        return lintDirectory(allocator, path, zig_lib_path, config, use_color, project_root, writer);
+        return lintDirectory(allocator, io, path, zig_lib_path, config, use_color, project_root, writer);
     }
 
-    return lintFile(allocator, path, zig_lib_path, config, use_color, project_root, writer);
+    return lintFile(allocator, io, path, zig_lib_path, config, use_color, project_root, writer);
 }
 
-fn lintDirectory(allocator: std.mem.Allocator, path: []const u8, zig_lib_path: ?[]const u8, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
-    var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch |err| {
+fn lintDirectory(allocator: std.mem.Allocator, io: std.Io, path: []const u8, zig_lib_path: ?[]const u8, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
+    var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
         try writer.print("error: cannot open directory '{s}': {}\n", .{ path, err });
         return 0;
     };
-    defer dir.close();
+    defer dir.close(io);
 
-    const gitignore = loadGitignore(allocator, dir);
+    const gitignore = loadGitignore(io, allocator, dir);
     defer if (gitignore) |g| allocator.free(g);
 
     // Collect all .zig files first
@@ -286,7 +306,7 @@ fn lintDirectory(allocator: std.mem.Allocator, path: []const u8, zig_lib_path: ?
     };
     defer walker.deinit();
 
-    while (walker.next() catch null) |entry| {
+    while (walker.next(io) catch null) |entry| {
         if (shouldSkip(entry.path, gitignore)) continue;
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
@@ -308,55 +328,55 @@ fn lintDirectory(allocator: std.mem.Allocator, path: []const u8, zig_lib_path: ?
         try writer.print("{s}┌─ {s}{s}{s} ({d} files)\n", .{ dim, reset, path, reset, files.items.len });
     }
 
-    var timer = if (config.verbose) std.time.Timer.start() catch null else null;
+    var timer = if (config.verbose) VerboseTimer.init(io) else null;
 
     // Build module graph once using first file as root, then add all others
-    const graph_start = if (timer) |*t| t.read() else 0;
-    var graph = ModuleGraph.init(allocator, files.items[0], zig_lib_path) catch {
+    const graph_start = if (timer) |*t| t.read(io) else 0;
+    var graph = ModuleGraph.init(io, allocator, files.items[0], zig_lib_path) catch {
         // Fall back to per-file linting without semantics
         if (config.verbose) {
             try writer.print("{s}│ module graph failed, using simple linting{s}\n", .{ dim, reset });
         }
         var total: usize = 0;
         for (files.items) |file_path| {
-            total += try lintFileSimple(allocator, file_path, config, use_color, project_root, writer);
+            total += try lintFileSimple(allocator, io, file_path, config, use_color, project_root, writer);
         }
         return total;
     };
     defer graph.deinit();
 
     if (config.verbose and timer != null) {
-        const elapsed = timer.?.read() - graph_start;
+        const elapsed = timer.?.read(io) - graph_start;
         try writer.print("{s}│ module graph:  {s}{d:>7.2}ms{s}\n", .{ dim, cyan, @as(f64, @floatFromInt(elapsed)) / 1_000_000.0, reset });
     }
 
     // Add remaining files to the graph
-    const add_start = if (timer) |*t| t.read() else 0;
+    const add_start = if (timer) |*t| t.read(io) else 0;
     for (files.items[1..]) |file_path| {
         graph.addModulePublic(file_path);
     }
 
     if (config.verbose and timer != null and files.items.len > 1) {
-        const elapsed = timer.?.read() - add_start;
+        const elapsed = timer.?.read(io) - add_start;
         try writer.print("{s}│ add files:     {s}{d:>7.2}ms{s} ({d} files)\n", .{ dim, cyan, @as(f64, @floatFromInt(elapsed)) / 1_000_000.0, reset, files.items.len - 1 });
     }
 
-    const resolver_start = if (timer) |*t| t.read() else 0;
+    const resolver_start = if (timer) |*t| t.read(io) else 0;
     var resolver: TypeResolver = .init(allocator, &graph);
     defer resolver.deinit();
 
     if (config.verbose and timer != null) {
-        const elapsed = timer.?.read() - resolver_start;
+        const elapsed = timer.?.read(io) - resolver_start;
         try writer.print("{s}│ type resolver: {s}{d:>7.2}ms{s}\n", .{ dim, cyan, @as(f64, @floatFromInt(elapsed)) / 1_000_000.0, reset });
     }
 
     var total: usize = 0;
     for (files.items) |file_path| {
-        total += try lintFileWithGraph(allocator, file_path, &graph, &resolver, config, use_color, project_root, writer);
+        total += try lintFileWithGraph(allocator, io, file_path, &graph, &resolver, config, use_color, project_root, writer);
     }
 
     if (config.verbose and timer != null) {
-        const total_time = timer.?.read();
+        const total_time = timer.?.read(io);
         try writer.print("{s}└─ total:        {s}{d:>7.2}ms{s}\n", .{ dim, cyan, @as(f64, @floatFromInt(total_time)) / 1_000_000.0, reset });
     }
 
@@ -401,12 +421,12 @@ fn matchesGitignore(path: []const u8, pattern: []const u8) bool {
     return std.mem.indexOf(u8, path, clean_pattern) != null;
 }
 
-fn loadGitignore(allocator: std.mem.Allocator, dir: std.fs.Dir) ?[]const u8 {
-    return dir.readFileAlloc(allocator, ".gitignore", 1024 * 64) catch null;
+fn loadGitignore(io: std.Io, allocator: std.mem.Allocator, dir: std.Io.Dir) ?[]const u8 {
+    return dir.readFileAlloc(io, ".gitignore", allocator, .limited(1024 * 64)) catch null;
 }
 
-fn lintFile(allocator: std.mem.Allocator, path: []const u8, zig_lib_path: ?[]const u8, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
-    var timer = if (config.verbose) std.time.Timer.start() catch null else null;
+fn lintFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, zig_lib_path: ?[]const u8, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
+    var timer = if (config.verbose) VerboseTimer.init(io) else null;
 
     const dim = if (use_color) "\x1b[2m" else "";
     const cyan = if (use_color) "\x1b[36m" else "";
@@ -416,42 +436,42 @@ fn lintFile(allocator: std.mem.Allocator, path: []const u8, zig_lib_path: ?[]con
         try writer.print("{s}┌─ {s}{s}{s}\n", .{ dim, reset, path, reset });
     }
 
-    const graph_start = if (timer) |*t| t.read() else 0;
-    var graph = ModuleGraph.init(allocator, path, zig_lib_path) catch {
-        return lintFileSimple(allocator, path, config, use_color, project_root, writer);
+    const graph_start = if (timer) |*t| t.read(io) else 0;
+    var graph = ModuleGraph.init(io, allocator, path, zig_lib_path) catch {
+        return lintFileSimple(allocator, io, path, config, use_color, project_root, writer);
     };
     defer graph.deinit();
 
     if (config.verbose and timer != null) {
-        const elapsed = timer.?.read() - graph_start;
+        const elapsed = timer.?.read(io) - graph_start;
         try writer.print("{s}│ module graph:  {s}{d:>7.2}ms{s}\n", .{ dim, cyan, @as(f64, @floatFromInt(elapsed)) / 1_000_000.0, reset });
     }
 
-    const resolver_start = if (timer) |*t| t.read() else 0;
+    const resolver_start = if (timer) |*t| t.read(io) else 0;
     var resolver: TypeResolver = .init(allocator, &graph);
     defer resolver.deinit();
 
     if (config.verbose and timer != null) {
-        const elapsed = timer.?.read() - resolver_start;
+        const elapsed = timer.?.read(io) - resolver_start;
         try writer.print("{s}│ type resolver: {s}{d:>7.2}ms{s}\n", .{ dim, cyan, @as(f64, @floatFromInt(elapsed)) / 1_000_000.0, reset });
     }
 
-    const result = try lintFileWithGraph(allocator, path, &graph, &resolver, config, use_color, project_root, writer);
+    const result = try lintFileWithGraph(allocator, io, path, &graph, &resolver, config, use_color, project_root, writer);
 
     if (config.verbose and timer != null) {
-        const total = timer.?.read();
+        const total = timer.?.read(io);
         try writer.print("{s}└─ total:        {s}{d:>7.2}ms{s}\n", .{ dim, cyan, @as(f64, @floatFromInt(total)) / 1_000_000.0, reset });
     }
 
     return result;
 }
 
-fn lintFileSimple(allocator: std.mem.Allocator, path: []const u8, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
-    const source = std.fs.cwd().readFileAllocOptions(
-        allocator,
+fn lintFileSimple(allocator: std.mem.Allocator, io: std.Io, path: []const u8, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
+    const source = std.Io.Dir.cwd().readFileAllocOptions(
+        io,
         path,
-        1024 * 1024 * 16,
-        null,
+        allocator,
+        .limited(1024 * 1024 * 16),
         .@"1",
         0,
     ) catch |err| {
@@ -463,12 +483,12 @@ fn lintFileSimple(allocator: std.mem.Allocator, path: []const u8, config: *const
     var linter: Linter = .init(allocator, source, path, &config.file_config);
     defer linter.deinit();
     linter.lint();
-    return writeDiagnostics(linter.diagnostics.items, config, use_color, project_root, writer);
+    return writeDiagnostics(allocator, linter.diagnostics.items, config, use_color, project_root, writer);
 }
 
-fn lintFileWithGraph(allocator: std.mem.Allocator, path: []const u8, graph: *ModuleGraph, resolver: *TypeResolver, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
+fn lintFileWithGraph(allocator: std.mem.Allocator, io: std.Io, path: []const u8, graph: *ModuleGraph, resolver: *TypeResolver, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
     const mod = graph.getModule(path) orelse {
-        return lintFileSimple(allocator, path, config, use_color, project_root, writer);
+        return lintFileSimple(allocator, io, path, config, use_color, project_root, writer);
     };
 
     const dim = if (use_color) "\x1b[2m" else "";
@@ -481,26 +501,26 @@ fn lintFileWithGraph(allocator: std.mem.Allocator, path: []const u8, graph: *Mod
     linter.verbose = config.verbose;
     linter.use_color = use_color;
 
-    var timer = if (config.verbose) std.time.Timer.start() catch null else null;
+    var timer = if (config.verbose) VerboseTimer.init(io) else null;
     linter.lint();
 
     if (config.verbose and timer != null) {
-        const elapsed = timer.?.read();
+        const elapsed = timer.?.read(io);
         try writer.print("{s}│ linting:       {s}{d:>7.2}ms{s}\n", .{ dim, cyan, @as(f64, @floatFromInt(elapsed)) / 1_000_000.0, reset });
     }
 
-    return writeDiagnostics(linter.diagnostics.items, config, use_color, project_root, writer);
+    return writeDiagnostics(allocator, linter.diagnostics.items, config, use_color, project_root, writer);
 }
 
-fn writeDiagnostics(diagnostics: []const Linter.Diagnostic, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
+fn writeDiagnostics(allocator: std.mem.Allocator, diagnostics: []const Linter.Diagnostic, config: *const Config, use_color: bool, project_root: ?[]const u8, writer: *std.Io.Writer) !usize {
     var count: usize = 0;
-    var rule_counts = std.AutoHashMap(rules.Rule, usize).init(std.heap.page_allocator);
-    defer rule_counts.deinit();
+    var rule_counts: std.AutoHashMapUnmanaged(rules.Rule, usize) = .empty;
+    defer rule_counts.deinit(allocator);
 
     for (diagnostics) |diag| {
         // Track rule counts for verbose output
         if (config.verbose) {
-            const entry = rule_counts.getOrPut(diag.rule) catch continue;
+            const entry = rule_counts.getOrPut(allocator, diag.rule) catch continue;
             if (!entry.found_existing) {
                 entry.value_ptr.* = 0;
             }
@@ -617,4 +637,56 @@ test "applyOnlyRules keeps ignore precedence" {
     try std.testing.expect(config.file_config.isRuleEnabled(.Z001));
     try std.testing.expect(!config.file_config.isRuleEnabled(.Z002));
     try std.testing.expect(!config.file_config.isRuleEnabled(.Z003));
+}
+
+/// Test-only Io provider matching the convention used by ModuleGraph/TypeResolver.
+fn testIo() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
+test "findProjectRoot returns owned slice from caller allocator (no leak)" {
+    // Regression: previously `findProjectRoot` allocated via std.heap.page_allocator
+    // and the result was never freed by the caller (memory leak per Copilot finding).
+    // The fixed signature takes an explicit allocator. Using std.testing.allocator
+    // here ensures the caller-side free succeeds and that no other allocations
+    // escape the function.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const io = testIo();
+    try tmp.dir.writeFile(io, .{ .sub_path = "build.zig", .data = "// minimal build.zig" });
+    try tmp.dir.createDirPath(io, "src");
+
+    const root_abs = try tmp.dir.realPathFileAlloc(io, "build.zig", std.testing.allocator);
+    defer std.testing.allocator.free(root_abs);
+
+    // Pass the build.zig path's directory as start; findProjectRoot should locate it.
+    const dir_of_root = std.fs.path.dirname(root_abs) orelse unreachable;
+
+    const found = findProjectRoot(std.testing.allocator, io, dir_of_root);
+    try std.testing.expect(found != null);
+    defer std.testing.allocator.free(found.?);
+
+    try std.testing.expectEqualStrings(dir_of_root, found.?);
+}
+
+test "findProjectRoot returns null when no build.zig is found" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const io = testIo();
+    try tmp.dir.createDirPath(io, "isolated/nested");
+
+    // realPathFileAlloc requires a regular file; resolve via a sentinel file.
+    try tmp.dir.writeFile(io, .{ .sub_path = "isolated/nested/sentinel", .data = "" });
+    const sentinel = try tmp.dir.realPathFileAlloc(io, "isolated/nested/sentinel", std.testing.allocator);
+    defer std.testing.allocator.free(sentinel);
+    const start = std.fs.path.dirname(sentinel) orelse unreachable;
+
+    // Walking up will eventually hit filesystem root without finding build.zig
+    // (the temp dir tree we created has no build.zig anywhere on the path).
+    // To make this deterministic regardless of host layout, just verify that
+    // either we get null OR a slice we can free without a leak.
+    const found = findProjectRoot(std.testing.allocator, io, start);
+    if (found) |p| std.testing.allocator.free(p);
 }

--- a/src/rules.zig
+++ b/src/rules.zig
@@ -102,7 +102,7 @@ pub const Rule = enum(u16) {
             // syntax highlight: .{...} over Type{...}
             // context is "preferred\x00original" format
             .Z010 => {
-                const sep = std.mem.indexOfScalar(u8, context, 0) orelse context.len;
+                const sep = std.mem.findScalar(u8, context, 0) orelse context.len;
                 const preferred = context[0..sep];
                 const original = if (sep < context.len) context[sep + 1 ..] else context;
                 try writer.print("prefer {s}`{s}", .{ d, r });
@@ -152,7 +152,7 @@ pub const Rule = enum(u16) {
             // file-struct @This() alias should match filename
             // context is "alias\x00expected" format
             .Z021 => {
-                const sep = std.mem.indexOfScalar(u8, context, 0) orelse context.len;
+                const sep = std.mem.findScalar(u8, context, 0) orelse context.len;
                 const alias = context[0..sep];
                 const expected = if (sep < context.len) context[sep + 1 ..] else context;
                 try writer.print("{s}@This(){s} alias {s}'{s}'{s} should match filename {s}'{s}'{s}", .{ b, r, y, alias, r, y, expected, r });
@@ -164,7 +164,7 @@ pub const Rule = enum(u16) {
             // argument order: type params, Allocator, Io, then other args
             // context is "current_kind\x00expected_before" format
             .Z023 => {
-                const sep = std.mem.indexOfScalar(u8, context, 0) orelse context.len;
+                const sep = std.mem.findScalar(u8, context, 0) orelse context.len;
                 const current = context[0..sep];
                 const before = if (sep < context.len) context[sep + 1 ..] else "";
                 try writer.print("{s}'{s}'{s} parameter should come before {s}'{s}'{s}", .{ y, current, r, y, before, r });
@@ -172,7 +172,7 @@ pub const Rule = enum(u16) {
             // line length exceeds limit
             // context is "actual_len\x00max_len" format
             .Z024 => {
-                const sep = std.mem.indexOfScalar(u8, context, 0) orelse context.len;
+                const sep = std.mem.findScalar(u8, context, 0) orelse context.len;
                 const actual = context[0..sep];
                 const max = if (sep < context.len) context[sep + 1 ..] else "120";
                 try writer.print("line exceeds {s}{s}{s} characters ({s}{s}{s} chars)", .{ y, max, r, y, actual, r });
@@ -194,7 +194,7 @@ pub const Rule = enum(u16) {
             // instance.decl -> Type.decl
             // context is "field_name\x00type_name"
             .Z027 => {
-                const sep = std.mem.indexOfScalar(u8, context, 0) orelse context.len;
+                const sep = std.mem.findScalar(u8, context, 0) orelse context.len;
                 const field = context[0..sep];
                 const type_name = if (sep < context.len) context[sep + 1 ..] else "";
                 try writer.print("access {s}'{s}'{s} through type {s}'{s}'{s} instead of instance", .{
@@ -221,7 +221,7 @@ pub const Rule = enum(u16) {
             },
             .Z032 => {
                 // context is "name\x00suggestion"
-                const sep = std.mem.indexOfScalar(u8, context, 0) orelse context.len;
+                const sep = std.mem.findScalar(u8, context, 0) orelse context.len;
                 const name = context[0..sep];
                 const suggestion = if (sep < context.len) context[sep + 1 ..] else "";
                 if (suggestion.len > 0) {
@@ -232,7 +232,7 @@ pub const Rule = enum(u16) {
             },
             .Z033 => {
                 // context is "name\x00word"
-                const sep = std.mem.indexOfScalar(u8, context, 0) orelse context.len;
+                const sep = std.mem.findScalar(u8, context, 0) orelse context.len;
                 const name = context[0..sep];
                 const word = if (sep < context.len) context[sep + 1 ..] else "";
                 try writer.print("identifier {s}'{s}'{s} contains redundant word {s}'{s}'{s}", .{ y, name, r, y, word, r });

--- a/src/rules.zig
+++ b/src/rules.zig
@@ -51,27 +51,21 @@ pub const Rule = enum(u16) {
 
     pub const Config = blk: {
         const enum_fields = @typeInfo(Rule).@"enum".fields;
-        var struct_fields: [enum_fields.len]std.builtin.Type.StructField = undefined;
+        var field_names: [enum_fields.len][]const u8 = undefined;
+        var field_types: [enum_fields.len]type = undefined;
+        var field_attrs: [enum_fields.len]std.builtin.Type.StructField.Attributes = undefined;
         for (enum_fields, 0..) |field, i| {
             const rule: Rule = @enumFromInt(field.value);
             const ConfigT = rule.ConfigType();
             const default_value: ConfigT = .{};
-            struct_fields[i] = .{
-                .name = field.name,
-                .type = ConfigT,
+            field_names[i] = field.name;
+            field_types[i] = ConfigT;
+            field_attrs[i] = .{
+                .@"align" = @alignOf(ConfigT),
                 .default_value_ptr = @ptrCast(&default_value),
-                .is_comptime = false,
-                .alignment = @alignOf(ConfigT),
             };
         }
-        break :blk @Type(.{
-            .@"struct" = .{
-                .layout = .auto,
-                .fields = &struct_fields,
-                .decls = &.{},
-                .is_tuple = false,
-            },
-        });
+        break :blk @Struct(.auto, null, &field_names, &field_types, &field_attrs);
     };
 
     pub fn code(self: Rule) []const u8 {
@@ -312,30 +306,31 @@ fn writeHighlightedStructInit(writer: *std.Io.Writer, code: []const u8, type_col
 // ziglint-ignore: Z023
 fn RuleConfig(comptime enabled_by_default: bool, comptime Extra: type) type {
     const extra_fields = @typeInfo(Extra).@"struct".fields;
+    const total = 1 + extra_fields.len;
 
-    var fields: [1 + extra_fields.len]std.builtin.Type.StructField = undefined;
+    var field_names: [total][]const u8 = undefined;
+    var field_types: [total]type = undefined;
+    var field_attrs: [total]std.builtin.Type.StructField.Attributes = undefined;
 
     const default_enabled: bool = enabled_by_default;
-    fields[0] = .{
-        .name = "enabled",
-        .type = bool,
+    field_names[0] = "enabled";
+    field_types[0] = bool;
+    field_attrs[0] = .{
+        .@"align" = @alignOf(bool),
         .default_value_ptr = @ptrCast(&default_enabled),
-        .is_comptime = false,
-        .alignment = @alignOf(bool),
     };
 
     for (extra_fields, 0..) |f, i| {
-        fields[1 + i] = f;
+        field_names[1 + i] = f.name;
+        field_types[1 + i] = f.type;
+        field_attrs[1 + i] = .{
+            .@"comptime" = f.is_comptime,
+            .@"align" = f.alignment,
+            .default_value_ptr = f.default_value_ptr,
+        };
     }
 
-    return @Type(.{
-        .@"struct" = .{
-            .layout = .auto,
-            .fields = &fields,
-            .decls = &.{},
-            .is_tuple = false,
-        },
-    });
+    return @Struct(.auto, null, &field_names, &field_types, &field_attrs);
 }
 
 test "rule codes" {


### PR DESCRIPTION
## Summary

A deep multi-agent audit of the fork diff (`bfcb30d..main`, the Zig 0.16 migration + hardening work from PRs #1–#4) surfaced one genuinely actionable defect, now fixed here.

**🔴 Critical: stack-overflow DoS on cyclic type aliases.** The `nodeIsTypeRef` / `varDeclIsTypeRef` / `identifierIsTypeRef` trio in `src/TypeResolver.zig` recursed with **no depth guard**. A cyclic alias such as `const a = b; const b = a;` (or self-referential `const a = a;`) in *any linted file* triggers unbounded recursion → stack overflow → crash. Since ziglint analyzes untrusted source, this is remotely triggerable.

PR #4's "harden resolver" added `max_alias_depth = 32` but applied it only to `findMethodInFileAsStructDepth`, missing this sibling family. The bug is pre-existing upstream (introduced by upstream `6b11b20`), so it's also a candidate upstream PR.

## Fix

Thread a `depth: u32` parameter through the recursive trio (via a new `nodeIsTypeRefDepth`), plus `fieldAccessIsTypeRef`. Each recursive hop increments `depth`; once `depth >= max_alias_depth` the chain returns `false`. The public `isTypeRef()` entry starts at depth 0. This mirrors the existing `findMethodInFileAsStructDepth` guard pattern exactly. No behavior change for non-cyclic input (32 hops is far beyond any real alias chain).

## Tests (TDD)

Three regression tests added to `src/TypeResolver.zig`:
- `isTypeRef: cyclic alias terminates without stack overflow` — `const a = b; const b = a;`
- `isTypeRef: self-referential alias terminates without stack overflow` — `const a = a;`
- `findFnInCurrentModule: cyclic method alias terminates via max_alias_depth` — locks in the pre-existing method-alias guard

The two `isTypeRef` tests **crash with a 10001-frame stack overflow before the fix** and pass after — proving they test the right thing.

## Validation

```
zig build test --summary all
Build Summary: 7/7 steps succeeded; 277/277 tests passed
+- run test 277 pass (277 total)
+- zig fmt success
+- run exe ziglint success   # self-lint clean
```

(274 baseline + 3 new tests.)

## Audit notes

The audit ran 5 review dimensions (correctness, memory-safety, robustness, performance, testing) with adversarial verification of every finding. Everything else was either already-correct fork code (verifiers confirmed PRs #1–#4 fixed the bugs they flagged) or refuted false positives (arena-allocator non-leaks, bounded AST/path loops, non-material micro-perf). Two minor test gaps were noted; the higher-value one (the method-alias guard) is covered here. The remaining gap — a fault-injection test for `doc_tests.zig:203`'s infra-error rethrow — is low severity and intentionally deferred (would require fragile I/O mocking).

> Note: CodeRabbit's local CLI could not complete on this Zig 0.16-dev repo (its sandbox can't provision the toolchain — full run timed out at 60 min, `--fast` produced no verdict). The CodeRabbit GitHub app can review this PR server-side.